### PR TITLE
Updated setter methods that enforce star-impedance and asset-info bei…

### DIFF
--- a/src/main/java/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
+++ b/src/main/java/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
@@ -63,9 +63,11 @@ class PowerTransformer @JvmOverloads constructor(mRID: String = "") : Conducting
      */
     override var assetInfo: PowerTransformerInfo? = null
         set(value) {
-            val invalidEnds = ends.filter { it.starImpedance != null }
-            require(invalidEnds.isEmpty()) {
-                "Unable to use a catalog for ${typeNameAndMRID()} because the following associated ends have a direct link to a star impedance: ${invalidEnds.map { it.typeNameAndMRID() }}."
+            if (value != null) {
+                val invalidEnds = ends.filter { it.starImpedance != null }
+                require(invalidEnds.isEmpty()) {
+                    "Unable to use a catalog for ${typeNameAndMRID()} because the following associated ends have a direct link to a star impedance: ${invalidEnds.map { it.typeNameAndMRID() }}."
+                }
             }
             field = value
         }

--- a/src/main/java/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
+++ b/src/main/java/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
@@ -44,7 +44,7 @@ abstract class TransformerEnd(mRID: String = "") : IdentifiedObject(mRID) {
 
     var starImpedance: TransformerStarImpedance? = null
         set(value) {
-            if (this is PowerTransformerEnd) {
+            if (this is PowerTransformerEnd && value != null) {
                 require(powerTransformer?.assetInfo == null) {
                     "Unable to use a star impedance for ${typeNameAndMRID()} directly because ${powerTransformer?.typeNameAndMRID()} references a catalog."
                 }

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerEndTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerEndTest.kt
@@ -84,6 +84,13 @@ internal class PowerTransformerEndTest {
     }
 
     @Test
+    internal fun onlyChecksForCatalogAssignedWithNonNullStarImpedance() {
+        val tx = PowerTransformer().apply { assetInfo = PowerTransformerInfo() }
+        val end = PowerTransformerEnd().apply { powerTransformer = tx }.also { tx.addEnd(it) }
+        end.starImpedance = null
+    }
+
+    @Test
     internal fun populatesResistanceReactanceDirectlyIfAvailable() {
         val end = PowerTransformerEnd().apply {
             r = 1.1

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerTest.kt
@@ -143,4 +143,15 @@ internal class PowerTransformerTest {
             .withMessage("Unable to use a catalog for ${tx.typeNameAndMRID()} because the following associated ends have a direct link to a star impedance: [${end.typeNameAndMRID()}].")
     }
 
+    @Test
+    internal fun onlyChecksForStarImpedanceAssignedWithNonNullCatalog() {
+        val tx = PowerTransformer()
+        PowerTransformerEnd()
+            .apply {
+                powerTransformer = tx
+                starImpedance = TransformerStarImpedance()
+            }.also { tx.addEnd(it) }
+        tx.assetInfo = null
+    }
+
 }


### PR DESCRIPTION
…ng mutually exclusive to allow for setting those values to null without running the mutually exclusive check.

Signed-off-by: Roberto Marquez <roberto.marquez@zepben.com>