### PR TITLE
Ewb 739 grpc result nullability

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,22 +2,26 @@
 
 ##### Breaking Changes
 
-* The network hierarchy has been updated to use CIM classes.
-* `getFeeder` has been deprecated.
+* `NetworkHierarchy` has been updated to use CIM classes.
+* `getFeeder` has been deprecated. Prefer the use of the more generic `getEquipmentContainer`.
+* `getIdentifiedObject` now returns a `NoSuchElementException` error if the requested object does not exist rather than a `null` successful result.
 
 ##### New Features
 
 * Added normal and current version of the connected equipment trace. See `Tracing` for details.
-* Added a generic API call for populating the `Equipment` of an `EquipmentContainer`.
+* Added a generic API call, `getEquipmentContainer`, for populating the `Equipment` of an
+  `EquipmentContainer`.
 * Added API calls for getting loops.
 
 ##### Enhancements
 
-* The network hierarchy now contains circuits and loops.
+* `NetworkHierarchy` now contains circuits and loops.
 
 ##### Fixes
 
-* None.
+* `getIdentifiedObjects` now adds unknown mRIDs to the failed collection.
+* Fixed an error in the typing for `GrpcResult` that allowed you to set a value to `null` without specifying a nullable type.
 
 ##### Notes
+
 * None.

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/CimConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/CimConsumerClient.kt
@@ -30,6 +30,11 @@ internal data class ExtractResult(val identifiedObject: IdentifiedObject?, val m
 /**
  * Base class that defines some helpful functions when producer clients are sending to the server.
  *
+ * WARNING: The [MultiObjectResult] operations below are not atomic upon a [BaseService], and thus if processing fails partway through, any previously
+ * successful additions will have been processed by the service, and thus you may have an incomplete service. Also note that adding to the service may not
+ * occur for an object if another object with the same mRID is already present in service. [MultiObjectResult.failed] can be used to check for mRIDs that
+ * were retrieved but not added to service. This should not be the case unless you are processing things concurrently.
+ *
  * @property T The base service to send objects from.
  */
 abstract class CimConsumerClient<T : BaseService> : GrpcClient() {
@@ -40,28 +45,36 @@ abstract class CimConsumerClient<T : BaseService> : GrpcClient() {
      * Exceptions that occur during sending will be caught and passed to all error handlers that have been registered by [addErrorHandler].
      *
      * @return A [GrpcResult] with a result of one of the following:
-     * - The item if found
-     * - null if an object could not be found or it was found but not added to [service] (see [BaseService.add]).
-     * - A [Throwable] if an error occurred while retrieving or processing the object, in which case, [GrpcResult.wasSuccessful] will return false.
+     * - When [GrpcResult.wasSuccessful], the item found, accessible via [GrpcResult.value].
+     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the the object, accessible via [GrpcResult.thrown]. One of:
+     *    - [NoSuchElementException] if the object could not be found.
+     *    - The gRPC error that occurred while retrieving the object
      */
-    abstract fun getIdentifiedObject(service: T, mRID: String): GrpcResult<IdentifiedObject?>
+    abstract fun getIdentifiedObject(service: T, mRID: String): GrpcResult<IdentifiedObject>
 
     /**
      * Retrieve the objects with the given [mRIDs] and store the results in the [service].
      *
      * Exceptions that occur during processing will be caught and passed to all error handlers that have been registered by [addErrorHandler].
      *
-     * WARNING: This operation is not atomic upon [service], and thus if processing fails partway through [mRIDs], any previously successful mRID will have been
-     * added to the service, and thus you may have an incomplete [BaseService]. Also note that adding to the [service] may not occur for an object if another
-     * object with the same mRID is already present in [service]. [MultiObjectResult.failed] can be used to check for mRIDs that were retrieved but not
-     * added to [service].
-     *
      * @return A [GrpcResult] with a result of one of the following:
-     * - A [MultiObjectResult] containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
-     *   If an item couldn't be added to [service] its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
-     * - A [Throwable] if an error occurred while retrieving or processing the objects, in which case, [GrpcResult.wasSuccessful] will return false.
-     * Note the warning above in this case.
+     * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
+     * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
+     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the the object, accessible via [GrpcResult.thrown].
+     * Note the [CimConsumerClient] warning in this case.
      */
     abstract fun getIdentifiedObjects(service: T, mRIDs: Iterable<String>): GrpcResult<MultiObjectResult>
+
+    internal fun processExtractResults(mRIDs: Iterable<String>, extracted: Sequence<ExtractResult>): MultiObjectResult {
+        val results = mutableMapOf<String, IdentifiedObject>()
+        val failed = mRIDs.toMutableSet()
+        extracted.forEach { result ->
+            result.identifiedObject?.let {
+                results[it.mRID] = it
+                failed.remove(it.mRID)
+            }
+        }
+        return MultiObjectResult(results, failed)
+    }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/DiagramConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/DiagramConsumerClient.kt
@@ -24,6 +24,11 @@ import io.grpc.ManagedChannel
 /**
  * Consumer client for a [DiagramService].
  *
+ * WARNING: The [MultiObjectResult] operations below are not atomic upon a [DiagramService], and thus if processing fails partway through, any previously
+ * successful additions will have been processed by the service, and thus you may have an incomplete service. Also note that adding to the service may not
+ * occur for an object if another object with the same mRID is already present in service. [MultiObjectResult.failed] can be used to check for mRIDs that
+ * were retrieved but not added to service. This should not be the case unless you are processing things concurrently.
+ *
  * @property stub The gRPC stub to be used to communicate with the server
  */
 class DiagramConsumerClient(
@@ -59,12 +64,14 @@ class DiagramConsumerClient(
      * Exceptions that occur during sending will be caught and passed to all error handlers that have been registered by [addErrorHandler].
      *
      * @return A [GrpcResult] with a result of one of the following:
-     * - The item if found
-     * - null if an object could not be found or it was found but not added to [service] (see [BaseService.add]).
-     * - A [Throwable] if an error occurred while retrieving or processing the object, in which case, [GrpcResult.wasSuccessful] will return false.
+     * - When [GrpcResult.wasSuccessful], the item found, accessible via [GrpcResult.value].
+     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the the object, accessible via [GrpcResult.thrown]. One of:
+     *    - [NoSuchElementException] if the object could not be found.
+     *    - The gRPC error that occurred while retrieving the object
      */
-    override fun getIdentifiedObject(service: DiagramService, mRID: String): GrpcResult<IdentifiedObject?> = tryRpc {
+    override fun getIdentifiedObject(service: DiagramService, mRID: String): GrpcResult<IdentifiedObject> = tryRpc {
         processIdentifiedObjects(service, setOf(mRID)).firstOrNull()?.identifiedObject
+            ?: throw NoSuchElementException("No object with mRID $mRID could be found.")
     }
 
     /**
@@ -72,26 +79,14 @@ class DiagramConsumerClient(
      *
      * Exceptions that occur during processing will be caught and passed to all error handlers that have been registered by [addErrorHandler].
      *
-     * WARNING: This operation is not atomic upon [service], and thus if processing fails partway through [mRIDs], any previously successful mRID will have been
-     * added to the service, and thus you may have an incomplete [DiagramService]. Also note that adding to the [service] may not occur for an object if another
-     * object with the same mRID is already present in [service]. [MultiObjectResult.failed] can be used to check for mRIDs that were retrieved but not
-     * added to [service].
-     *
      * @return A [GrpcResult] with a result of one of the following:
-     * - A [MultiObjectResult] containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
-     *   If an item couldn't be added to [service] its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
-     * - A [Throwable] if an error occurred while retrieving or processing the objects, in which case, [GrpcResult.wasSuccessful] will return false.
-     * Note the warning above in this case.
+     * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
+     * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
+     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the the object, accessible via [GrpcResult.thrown].
+     * Note the [DiagramConsumerClient] warning in this case.
      */
     override fun getIdentifiedObjects(service: DiagramService, mRIDs: Iterable<String>): GrpcResult<MultiObjectResult> = tryRpc {
-        processIdentifiedObjects(service, mRIDs.toSet()).let { extracted ->
-            val results = mutableMapOf<String, IdentifiedObject>()
-            val failed = mutableSetOf<String>()
-            extracted.forEach {
-                if (it.identifiedObject == null) failed.add(it.mRID) else results[it.identifiedObject.mRID] = it.identifiedObject
-            }
-            MultiObjectResult(results, failed)
-        }
+        processExtractResults(mRIDs, processIdentifiedObjects(service, mRIDs.toSet()))
     }
 
 
@@ -110,12 +105,19 @@ class DiagramConsumerClient(
             } + existing
     }
 
-    private fun extractIdentifiedObject(service: DiagramService, it: DiagramIdentifiedObject): ExtractResult {
-        return when (it.identifiedObjectCase) {
-            DIAGRAM -> ExtractResult(protoToCimProvider(service).addFromPb(it.diagram), it.diagram.mRID())
-            DIAGRAMOBJECT -> ExtractResult(protoToCimProvider(service).addFromPb(it.diagramObject), it.diagramObject.mRID())
-            OTHER, IDENTIFIEDOBJECT_NOT_SET, null -> throw UnsupportedOperationException("Identified object type ${it.identifiedObjectCase} is not supported by the diagram service")
+    private fun extractIdentifiedObject(service: DiagramService, io: DiagramIdentifiedObject): ExtractResult {
+        return when (io.identifiedObjectCase) {
+            DIAGRAM -> extractResult(service, io.diagram.mRID()) { it.addFromPb(io.diagram) }
+            DIAGRAMOBJECT -> extractResult(service, io.diagramObject.mRID()) { it.addFromPb(io.diagramObject) }
+            OTHER, IDENTIFIEDOBJECT_NOT_SET, null -> throw UnsupportedOperationException("Identified object type ${io.identifiedObjectCase} is not supported by the diagram service")
         }
     }
+
+    private inline fun <reified CIM : IdentifiedObject> extractResult(
+        service: DiagramService,
+        mRID: String,
+        addFromPb: (DiagramProtoToCim) -> CIM?
+    ): ExtractResult =
+        ExtractResult(service[mRID] ?: addFromPb(protoToCimProvider(service)), mRID)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcResult.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcResult.kt
@@ -101,7 +101,7 @@ data class GrpcResult<T>(
          * Create a new successful [GrpcResult].
          */
         @JvmStatic
-        fun <T> of(result: T?): GrpcResult<T> {
+        fun <T> of(result: T): GrpcResult<T> {
             return GrpcResult(result, false)
         }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/CustomerConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/CustomerConsumerClientTest.kt
@@ -7,6 +7,7 @@
  */
 package com.zepben.evolve.streaming.get
 
+import com.nhaarman.mockitokotlin2.*
 import com.zepben.evolve.cim.iec61968.customers.Customer
 import com.zepben.evolve.cim.iec61968.customers.CustomerAgreement
 import com.zepben.evolve.services.customer.CustomerService
@@ -18,16 +19,14 @@ import com.zepben.protobuf.cc.CustomerConsumerGrpc
 import com.zepben.protobuf.cc.CustomerIdentifiedObject
 import com.zepben.protobuf.cc.GetIdentifiedObjectsRequest
 import com.zepben.protobuf.cc.GetIdentifiedObjectsResponse
+import com.zepben.testutils.exception.ExpectException.expect
 import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.*
 
 internal class CustomerConsumerClientTest {
 
@@ -35,10 +34,9 @@ internal class CustomerConsumerClientTest {
     @RegisterExtension
     var systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
 
-    private val stub = mock(CustomerConsumerGrpc.CustomerConsumerBlockingStub::class.java)
+    private val stub = mock<CustomerConsumerGrpc.CustomerConsumerBlockingStub>()
     private val onErrorHandler = CaptureLastRpcErrorHandler()
-    private val consumerClient: CustomerConsumerClient =
-        CustomerConsumerClient(stub).apply { addErrorHandler(onErrorHandler) }
+    private val consumerClient: CustomerConsumerClient = CustomerConsumerClient(stub).apply { addErrorHandler(onErrorHandler) }
     private val service: CustomerService = CustomerService()
 
     @Test
@@ -57,7 +55,7 @@ internal class CustomerConsumerClientTest {
             val type = response.identifiedObjectsList[0].identifiedObjectCase
             if (isSupported(type)) {
                 assertThat(result.wasSuccessful, equalTo(true))
-                assertThat(result.value?.mRID, equalTo(mRID))
+                assertThat(result.value.mRID, equalTo(mRID))
             } else {
                 assertThat(result.wasFailure, equalTo(true))
                 assertThat(result.thrown, instanceOf(UnsupportedOperationException::class.java))
@@ -71,6 +69,20 @@ internal class CustomerConsumerClientTest {
             verify(stub).getIdentifiedObjects(GetIdentifiedObjectsRequest.newBuilder().addMrids(mRID).build())
             clearInvocations(stub)
         }
+    }
+
+    @Test
+    internal fun `returns error when object is not found`() {
+        val mRID = "unknown"
+        doReturn(listOf<GetIdentifiedObjectsResponse>().iterator()).`when`(stub).getIdentifiedObjects(any())
+
+        val result = consumerClient.getIdentifiedObject(service, mRID)
+
+        verify(stub).getIdentifiedObjects(GetIdentifiedObjectsRequest.newBuilder().addMrids(mRID).build())
+        assertThat(result.wasFailure, equalTo(true))
+        expect { throw result.thrown }
+            .toThrow(NoSuchElementException::class.java)
+            .withMessage("No object with mRID $mRID could be found.")
     }
 
     @Test
@@ -159,20 +171,20 @@ internal class CustomerConsumerClientTest {
     }
 
     @Test
-    internal fun `getIdentifiedObjects returns failed mRID when duplicate mRIDs are returned`() {
-        val response = createResponse(CustomerIdentifiedObject.newBuilder(), CustomerIdentifiedObject.Builder::getCustomerBuilder, "id1")
+    internal fun `getIdentifiedObjects returns failed mRID when an mRID is not found`() {
+        val mRIDs = listOf("id1", "id2")
+        val response = createResponse(CustomerIdentifiedObject.newBuilder(), CustomerIdentifiedObject.Builder::getCustomerBuilder, mRIDs[0])
 
-        // We are only testing behaviour of duplicate responses when adding to the service.
-        doReturn(listOf(response, response).iterator()).`when`(stub).getIdentifiedObjects(any())
+        doReturn(listOf(response).iterator()).`when`(stub).getIdentifiedObjects(any())
 
-        val result = consumerClient.getIdentifiedObjects(service, setOf("id1"))
+        val result = consumerClient.getIdentifiedObjects(service, mRIDs)
 
         assertThat(result.wasSuccessful, equalTo(true))
         assertThat(result.value.objects.size, equalTo(1))
         assertThat(result.value.objects["id1"], instanceOf(Customer::class.java))
-        assertThat(result.value.failed, Matchers.contains("id1"))
+        assertThat(result.value.failed, containsInAnyOrder(mRIDs[1]))
 
-        verify(stub).getIdentifiedObjects(GetIdentifiedObjectsRequest.newBuilder().addAllMrids(listOf("id1")).build())
+        verify(stub).getIdentifiedObjects(GetIdentifiedObjectsRequest.newBuilder().addAllMrids(mRIDs).build())
         clearInvocations(stub)
     }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcResultTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcResultTest.kt
@@ -35,7 +35,7 @@ internal class GrpcResultTest {
 
     @Test
     internal fun canCreateNullResult() {
-        val result: GrpcResult<Int> = GrpcResult.of(null)
+        val result: GrpcResult<Int?> = GrpcResult.of(null)
 
         assertThat(result.wasSuccessful, equalTo(true))
         assertThat(result.value, nullValue())


### PR DESCRIPTION
* `getIdentifiedObject` now returns a `NoSuchElementException` error if the requested object does not exist rather than a `null` successful result.
* `getIdentifiedObjects` now adds unknown mRIDs to the failed collection.
* Fixed an error in the typing for `GrpcResult` that allowed you to set a value to `null` without specifying a nullable type.
