### PR TITLE
Add clarification for restrictions on starImpedance and assetInfo for transformers

### DIFF
--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
@@ -45,7 +45,7 @@ import com.zepben.evolve.services.common.extensions.*
  *
  * @property assetInfo Set of power transformer data, from an equipment library or data sheet. Note that when this is set to a [PowerTransformerInfo], the
  * corresponding [TransformerEnd]s cannot be associated directly with a [TransformerStarImpedance], as the existence of [assetInfo] indicates that impedance
- * values is calculated from the data sheet information.
+ * values are calculated from the data sheet information.
  */
 class PowerTransformer @JvmOverloads constructor(mRID: String = "") : ConductingEquipment(mRID) {
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
@@ -16,38 +16,37 @@ import com.zepben.evolve.services.common.extensions.*
  * An electrical device consisting of  two or more coupled windings, with or without a magnetic core, for introducing mutual coupling
  * between electric circuits. Transformers can be used to control voltage and phase shift (active power flow).
  *
- *
  * A power transformer may be composed of separate transformer tanks that need not be identical.
- *
  *
  * A power transformer can be modeled with or without tanks and is intended for use in both balanced and unbalanced representations. A
  * power transformer typically has two terminals, but may have one (grounding), three or more terminals.
- *
  *
  * The inherited association ConductingEquipment.BaseVoltage should not be used.  The association from TransformerEnd to BaseVoltage
  * should be used instead.
  *
  * @property vectorGroup Vector group of the transformer for protective relaying, e.g., Dyn1. For unbalanced transformers, this may not be simply
- *                       determined from the constituent winding connections and phase angle displacements.
+ * determined from the constituent winding connections and phase angle displacements.
  *
- *                       The vectorGroup string consists of the following components in the order listed: high voltage winding connection, mid
- *                       voltage winding connection(for three winding transformers), phase displacement clock number from 0 to 11,  low voltage
- *                       winding connection phase displacement clock number from 0 to 11.   The winding connections are D(delta), Y(wye),
- *                       YN(wye with neutral), Z(zigzag), ZN(zigzag with neutral), A(auto transformer). Upper case means the high voltage,
- *                       lower case mid or low.The high voltage winding always has clock position 0 and is not included in the vector group
- *                       string.  Some examples: YNy0(two winding wye to wye with no phase displacement), YNd11(two winding wye to delta with
- *                       330 degrees phase displacement), YNyn0d5(three winding transformer wye with neutral high voltage, wye with neutral mid
- *                       voltage and no phase displacement, delta low voltage with 150 degrees displacement).
+ * The vectorGroup string consists of the following components in the order listed: high voltage winding connection, mid voltage winding connection(for three
+ * winding transformers), phase displacement clock number from 0 to 11,  low voltage winding connection phase displacement clock number from 0 to 11.
+ * The winding connections are D(delta), Y(wye), YN(wye with neutral), Z(zigzag), ZN(zigzag with neutral), A(auto transformer). Upper case means the high
+ * voltage, lower case mid or low.The high voltage winding always has clock position 0 and is not included in the vector group string.
+ * Some examples: YNy0(two winding wye to wye with no phase displacement), YNd11(two winding wye to delta with 330 degrees phase displacement),
+ * YNyn0d5(three winding transformer wye with neutral high voltage, wye with neutral mid voltage and no phase displacement, delta low voltage with 150 degrees
+ * displacement).
  *
- *                       Phase displacement is defined as the angular difference between the phasors representing the voltages between the
- *                       neutral point(real or imaginary) and the corresponding terminals of two windings, a positive sequence voltage system
- *                       being applied to the high-voltage terminals, following each other in alphabetical sequence if they are lettered, or in
- *                       numerical sequence if they are numbered: the phasors are assumed to rotate in a counter-clockwise sense.
+ * Phase displacement is defined as the angular difference between the phasors representing the voltages between the neutral point(real or imaginary) and the
+ * corresponding terminals of two windings, a positive sequence voltage system being applied to the high-voltage terminals, following each other in
+ * alphabetical sequence if they are lettered, or in numerical sequence if they are numbered: the phasors are assumed to rotate in a counter-clockwise sense.
  *
  * @property primaryVoltage Holds the primary voltage value for a transformer.
- * @property transformerUtilisation The fraction of the transformer’s normal capacity (nameplate rating) that is in use. It may be expressed as the
- *                                  result of the calculation S/Sn, where S = Load on Transformer (in VA), Sn = Transformer Nameplate Rating (in VA).
- *                                  A value of NaN signifies the data is missing/unknown.
+ *
+ * @property transformerUtilisation The fraction of the transformer’s normal capacity (nameplate rating) that is in use. It may be expressed as the result of
+ * the calculation S/Sn, where S = Load on Transformer (in VA), Sn = Transformer Nameplate Rating (in VA). A value of NaN signifies the data is missing/unknown.
+ *
+ * @property assetInfo Set of power transformer data, from an equipment library or data sheet. Note that when this is set to a [PowerTransformerInfo] the
+ * corresponding [TransformerEnd]s cannot be associated with a [starImpedance], as the existence of [assetInfo] indicates that impedance values is * calculated
+ * from the data sheet information.
  */
 class PowerTransformer @JvmOverloads constructor(mRID: String = "") : ConductingEquipment(mRID) {
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
@@ -8,7 +8,6 @@
 package com.zepben.evolve.cim.iec61970.base.wires
 
 import com.zepben.evolve.cim.iec61968.assetinfo.PowerTransformerInfo
-import com.zepben.evolve.cim.iec61968.assets.AssetInfo
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.evolve.services.common.extensions.*
 
@@ -44,9 +43,9 @@ import com.zepben.evolve.services.common.extensions.*
  * @property transformerUtilisation The fraction of the transformer’s normal capacity (nameplate rating) that is in use. It may be expressed as the result of
  * the calculation S/Sn, where S = Load on Transformer (in VA), Sn = Transformer Nameplate Rating (in VA). A value of NaN signifies the data is missing/unknown.
  *
- * @property assetInfo Set of power transformer data, from an equipment library or data sheet. Note that when this is set to a [PowerTransformerInfo] the
- * corresponding [TransformerEnd]s cannot be associated with a [starImpedance], as the existence of [assetInfo] indicates that impedance values is * calculated
- * from the data sheet information.
+ * @property assetInfo Set of power transformer data, from an equipment library or data sheet. Note that when this is set to a [PowerTransformerInfo], the
+ * corresponding [TransformerEnd]s cannot be associated directly with a [TransformerStarImpedance], as the existence of [assetInfo] indicates that impedance
+ * values is calculated from the data sheet information.
  */
 class PowerTransformer @JvmOverloads constructor(mRID: String = "") : ConductingEquipment(mRID) {
 
@@ -57,9 +56,6 @@ class PowerTransformer @JvmOverloads constructor(mRID: String = "") : Conducting
     var vectorGroup: VectorGroup = VectorGroup.UNKNOWN
     var transformerUtilisation: Double? = null
 
-    /**
-     * Override the [AssetInfo] as [PowerTransformerInfo].
-     */
     override var assetInfo: PowerTransformerInfo? = null
         set(value) {
             if (value != null) {

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
@@ -7,6 +7,7 @@
  */
 package com.zepben.evolve.cim.iec61970.base.wires
 
+import com.zepben.evolve.cim.iec61968.assetinfo.PowerTransformerInfo
 import com.zepben.evolve.cim.iec61970.base.core.BaseVoltage
 import com.zepben.evolve.cim.iec61970.base.core.IdentifiedObject
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
@@ -30,7 +31,7 @@ import com.zepben.evolve.services.network.ResistanceReactance
  *
  * @property starImpedance (accurate for 2- or 3-winding transformers only) Pi-model impedances of this transformer end. By convention, for a two winding
  * transformer, the full values of the transformer should be entered on the high voltage end (endNumber=1).
- * When [starImpedance] is set here it indicates that impedance values are measured on the [TransformerEnd] itself rather than from the PowerTransformer data
+ * When [starImpedance] is set here it indicates that impedance values are measured on the [TransformerEnd] itself rather than from the [PowerTransformer] data
  * sheet, and thus the corresponding [PowerTransformer] for this end cannot have an associated [PowerTransformerInfo].
  */
 abstract class TransformerEnd(mRID: String = "") : IdentifiedObject(mRID) {

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/TransformerEnd.kt
@@ -25,10 +25,13 @@ import com.zepben.evolve.services.network.ResistanceReactance
  * @property ratioTapChanger Ratio tap changer associated with this transformer end.
  * @property terminal The terminal of the transformer that this end is associated with
  * @property endNumber Number for this transformer end, corresponding to the end's order in the power transformer vector group or phase angle clock number.
- *                     Highest voltage winding should be 1. Each end within a power transformer should have a unique subsequent end number. Note the
- *                     transformer end number need not match the terminal sequence number.
+ * Highest voltage winding should be 1. Each end within a power transformer should have a unique subsequent end number. Note the transformer end number need not
+ * match the terminal sequence number.
+ *
  * @property starImpedance (accurate for 2- or 3-winding transformers only) Pi-model impedances of this transformer end. By convention, for a two winding
- *                         transformer, the full values of the transformer should be entered on the high voltage end (endNumber=1).
+ * transformer, the full values of the transformer should be entered on the high voltage end (endNumber=1).
+ * When [starImpedance] is set here it indicates that impedance values are measured on the [TransformerEnd] itself rather than from the PowerTransformer data
+ * sheet, and thus the corresponding [PowerTransformer] for this end cannot have an associated [PowerTransformerInfo].
  */
 abstract class TransformerEnd(mRID: String = "") : IdentifiedObject(mRID) {
 


### PR DESCRIPTION
When we get this sounding accurate/reasonable I'll make the addition to the python SDK as well.

Sorry about the noise, had to fix formatting so that the []'s actually worked properly in the IDE. Basically you're only looking at the last block of text in each comment (starImpedance and assetInfo)