### PR TITLE
Return true if object already in service

### DIFF
--- a/src/main/kotlin/com/zepben/evolve/services/common/BaseService.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/BaseService.kt
@@ -282,7 +282,7 @@ abstract class BaseService(
         }
 
         val map = objectsByType.computeIfAbsent(identifiedObject::class) { mutableMapOf() }
-        if (map.containsKey(identifiedObject.mRID)) return false
+        if (map.containsKey(identifiedObject.mRID)) return map[identifiedObject.mRID] == identifiedObject
 
         // Check all the other types to make sure this MRID is actually unique
         if (objectsByType.any { (_, v) -> v.containsKey(identifiedObject.mRID) })

--- a/src/main/kotlin/com/zepben/evolve/services/common/BaseService.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/BaseService.kt
@@ -282,7 +282,7 @@ abstract class BaseService(
         }
 
         val map = objectsByType.computeIfAbsent(identifiedObject::class) { mutableMapOf() }
-        if (map.containsKey(identifiedObject.mRID)) return map[identifiedObject.mRID] == identifiedObject
+        if (map.containsKey(identifiedObject.mRID)) return map[identifiedObject.mRID] === identifiedObject
 
         // Check all the other types to make sure this MRID is actually unique
         if (objectsByType.any { (_, v) -> v.containsKey(identifiedObject.mRID) })

--- a/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
@@ -231,6 +231,27 @@ internal class BaseServiceTest {
     }
 
     @Test
+    fun `add returns true when object already in service`() {
+        val ns = NetworkService()
+
+        AcLineSegment("acls1").apply {
+            assertThat(ns.add(this), equalTo(true))
+            // Re-adding the same object should return true
+            assertThat(ns.add(this), equalTo(true))
+        }
+
+        // a new ACLS with the same mRID should fail
+        AcLineSegment("acls1").apply {
+            assertThat(ns.add(this), equalTo(false))
+        }
+
+        // A completely different object with the same mRID should fail
+        Junction("acls1").apply {
+            assertThat(ns.add(this), equalTo(false))
+        }
+    }
+
+    @Test
     internal fun `throws cast exception when getting wrong type`() {
         expect { service.get(Junction::class, breaker1.mRID) }.toThrow(ClassCastException::class.java)
     }

--- a/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
@@ -252,6 +252,17 @@ internal class BaseServiceTest {
     }
 
     @Test
+    fun `add only returns true when object is the same instance, not just equal`() {
+        val ms = MyService()
+        val obj1 = MyIdentifiedObject("1")
+        val obj1Dup = MyIdentifiedObject("1")
+
+        assertThat(ms.add(obj1), equalTo(true))
+        assertThat(ms.add(obj1), equalTo(true))
+        assertThat(ms.add(obj1Dup), equalTo(false))
+    }
+
+    @Test
     internal fun `throws cast exception when getting wrong type`() {
         expect { service.get(Junction::class, breaker1.mRID) }.toThrow(ClassCastException::class.java)
     }
@@ -281,4 +292,15 @@ internal class BaseServiceTest {
         service.sequenceOf<T>().filter(filter).forEach { visited.add(it) }
         assertThat(visited, containsInAnyOrder<Any>(*expected.toTypedArray()))
     }
+
+    private class MyIdentifiedObject(mrid: String) : IdentifiedObject(mrid) {
+        override fun equals(other: Any?): Boolean = true
+        override fun hashCode(): Int = 0
+    }
+
+    private class MyService : BaseService("") {
+        fun add(cableInfo: MyIdentifiedObject): Boolean = super.add(cableInfo)
+        fun remove(cableInfo: MyIdentifiedObject): Boolean = super.remove(cableInfo)
+    }
+
 }


### PR DESCRIPTION
I think this behaviour makes more sense (it's even in line with the function docs) - basically if you add something that is already in the service you still get back a return of true. That way if people add the same thing multiple times they can still rely on add to tell them if it's in the service.

I'm doubtful that anyone is relying on the existing behaviour so I think it'd be safe to merge.