### PR TITLE
PROJ-2313 - `SetDirection` now correctly handles `Switch` instances without phases.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
 * None.
 
 ##### Fixes
-* None.
+* `SetDirection` now correctly handles `Switch` instances without phases.
 
 ##### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
@@ -145,7 +145,7 @@ class SetDirection {
             return
 
         val ce = terminal.conductingEquipment ?: return
-        if (terminal.phases.singlePhases.all { openTest.isOpen(ce, it) })
+        if (openTest.isOpen(ce, null))
             return
 
         ce.terminals

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -332,6 +332,30 @@ class SetDirectionTest {
         n.getT("c2", 2).validateDirections(DOWNSTREAM)
     }
 
+    @Test
+    internal fun worksWithoutPhase() {
+        //
+        // j0 11--c1--21--c2--2
+        //
+        val n = TestNetworkBuilder
+            .startWithJunction(numTerminals = 1, nominalPhases = PhaseCode.NONE) // j0
+            .toAcls(nominalPhases = PhaseCode.NONE) // c1
+            .toBreaker(PhaseCode.NONE, isNormallyOpen = true)
+            .toAcls(nominalPhases = PhaseCode.NONE) // c2
+            .network
+
+        SetDirection().run(n.getT("j0", 1))
+        DirectionLogger.trace(n["j0"])
+
+        n.getT("j0", 1).validateDirections(DOWNSTREAM)
+        n.getT("c1", 1).validateDirections(UPSTREAM)
+        n.getT("c1", 2).validateDirections(DOWNSTREAM)
+        n.getT("b2", 1).validateDirections(UPSTREAM)
+        n.getT("b2", 2).validateDirections(NONE)
+        n.getT("c3", 1).validateDirections(NONE)
+        n.getT("c3", 2).validateDirections(NONE)
+    }
+
     private fun doSetDirectionTrace(n: NetworkService) {
         SetDirection().run(n)
         n.sequenceOf<Feeder>().forEach { DirectionLogger.trace(it.normalHeadTerminal!!.conductingEquipment!!) }


### PR DESCRIPTION
Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>