### PR TITLE
`Terminal` helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ##### Breaking Changes
 
-* None.
+* Made `Terminal` methods `connect` and `disconnect` internal as they were always meant to be. If you have been incorrectly using them, you will need to swap to
+  using the methods from `NetworkService` instead.
 
 ##### New Features
 
@@ -10,7 +11,7 @@
 
 ##### Enhancements
 
-* None.
+* Added `connectedTerminals` and `otherTerminals` helper methods to `Terminal`.
 
 ##### Fixes
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Terminal.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Terminal.kt
@@ -80,10 +80,26 @@ class Terminal @JvmOverloads constructor(mRID: String = "") : AcDcTerminal(mRID)
      */
     val currentPhases: PhaseStatus = PhaseSelector.CURRENT_PHASES.phases(this)
 
+    /**
+     * Get the terminals that are connected to this [Terminal].
+     *
+     * @return A [Sequence] of terminals that are connected to this [Terminal].
+     */
+    fun connectedTerminals(): Sequence<Terminal> =
+        connectivityNode?.terminals?.asSequence()?.filter { other -> other != this } ?: emptySequence()
+
+    /**
+     * Get the terminals that share the same [ConductingEquipment] as this [Terminal].
+     *
+     * @return A [Sequence] of terminals that share the same [ConductingEquipment] as this [Terminal].
+     */
+    fun otherTerminals(): Sequence<Terminal> =
+        conductingEquipment?.terminals?.asSequence()?.filter { other -> other != this } ?: emptySequence()
+
     // NOTE: This is meant to be package private to prevent external linking of objects. Use the network
     //       to connect from outside this package.
     //
-    fun connect(connectivityNode: ConnectivityNode) {
+    internal fun connect(connectivityNode: ConnectivityNode) {
         this._connectivityNode = WeakReference(connectivityNode)
     }
 
@@ -91,7 +107,7 @@ class Terminal @JvmOverloads constructor(mRID: String = "") : AcDcTerminal(mRID)
     // NOTE: This is meant to be package private to prevent external linking of objects. Use the network
     //       to disconnect from outside this package. It could be made 'internal' when all other classes are ported to Kotlin
     //
-    fun disconnect() {
+    internal fun disconnect() {
         _connectivityNode = NO_CONNECTIVITY_NODE
     }
 

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/TerminalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/TerminalTest.kt
@@ -76,6 +76,44 @@ internal class TerminalTest {
     }
 
     @Test
+    internal fun connectedTerminals() {
+        val terminal1 = Terminal()
+        val terminal2 = Terminal()
+        val terminal3 = Terminal()
+        val networkService = NetworkService()
+
+        assertThat(terminal1.connectedTerminals().toList(), empty())
+
+        networkService.connect(terminal1, "cn1")
+        assertThat(terminal1.connectedTerminals().toList(), empty())
+
+        networkService.connect(terminal2, "cn1")
+        assertThat(terminal1.connectedTerminals().toList(), containsInAnyOrder(terminal2))
+
+        networkService.connect(terminal3, "cn1")
+        assertThat(terminal1.connectedTerminals().toList(), containsInAnyOrder(terminal2, terminal3))
+    }
+
+    @Test
+    internal fun otherTerminals() {
+        val terminal1 = Terminal()
+        val terminal2 = Terminal()
+        val terminal3 = Terminal()
+        val ce = Junction()
+
+        assertThat(terminal1.otherTerminals().toList(), empty())
+
+        ce.addTerminal(terminal1)
+        assertThat(terminal1.otherTerminals().toList(), empty())
+
+        ce.addTerminal(terminal2)
+        assertThat(terminal1.otherTerminals().toList(), containsInAnyOrder(terminal2))
+
+        ce.addTerminal(terminal3)
+        assertThat(terminal1.otherTerminals().toList(), containsInAnyOrder(terminal2, terminal3))
+    }
+
+    @Test
     internal fun tracedPhases() {
         val terminal = Terminal()
 


### PR DESCRIPTION
* Added `connectedTerminals` and `otherTerminals` helper methods to `Terminal`
* Made `Terminal` methods `connect` and `disconnect` internal.

Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>