### PR TITLE
Changed `TestNetworkBuilder` to handle 'other' better, and not be statically constructed.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ##### Breaking Changes
 
-* None. 
+* Changed `TestNetworkBuilder` to have a public constructor and removed `startWith*` functions. Change `TestNetworkBuilder.startWith*` to
+  `TestNetworkBuilder().from*` _(kotlin)_, or `new TestNetworkBuilder().from*` _(java)_.
+* Changed `TestNetworkBuilder.fromOther` and `TestNetworkBuilder.toOther` to take a creator, rather than an instance.
 
 ##### New Features
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/RemoveDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/RemoveDirectionTest.kt
@@ -27,8 +27,8 @@ class RemoveDirectionTest {
     //
     // j0 --c1-- --c2-- j3
     //
-    private val nb = TestNetworkBuilder
-        .startWithJunction(PhaseCode.A, 1) // j0
+    private val nb = TestNetworkBuilder()
+        .fromJunction(PhaseCode.A, 1) // j0
         .toAcls(PhaseCode.A) // c1
         .toAcls(PhaseCode.A) // c2
         .toJunction(PhaseCode.A, 1) // j3
@@ -229,8 +229,8 @@ class RemoveDirectionTest {
         //               1
         //               j6
         //
-        val n = TestNetworkBuilder
-            .startWithJunction(PhaseCode.A, 1)
+        val n = TestNetworkBuilder()
+            .fromJunction(PhaseCode.A, 1)
             .toAcls(PhaseCode.A) // c1
             .toJunction(PhaseCode.A, 3) // j2
             .toAcls(PhaseCode.A) // c3

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -64,8 +64,8 @@ class SetDirectionTest {
         // 1--c0--21 b1 21--c2--2
         //         1 b3 21--c4--2
         //
-        val n = TestNetworkBuilder
-            .startWithAcls() // c0
+        val n = TestNetworkBuilder()
+            .fromAcls() // c0
             .toBreaker(isNormallyOpen = true, isOpen = false) // b1
             .toAcls() // c2
             .branchFrom("c0")
@@ -95,8 +95,8 @@ class SetDirectionTest {
         //
         // * = feeder start
         //
-        val n = TestNetworkBuilder
-            .startWithAcls() // c0
+        val n = TestNetworkBuilder()
+            .fromAcls() // c0
             .toJunction() // j1
             .toAcls() // c2
             .toJunction() // j3
@@ -127,8 +127,8 @@ class SetDirectionTest {
         //                |__________________|
         //                         c9
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.A) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.A) // s0
             .toAcls(PhaseCode.A) // c1
             .toJunction(PhaseCode.A) // j2
             .toAcls(PhaseCode.A) // c3
@@ -183,8 +183,8 @@ class SetDirectionTest {
         //               |                   |
         //               \-c3--21 j4 21---c5-/
         //
-        val n = TestNetworkBuilder
-            .startWithJunction(numTerminals = 1) // j0
+        val n = TestNetworkBuilder()
+            .fromJunction(numTerminals = 1) // j0
             .toAcls() // c1
             .toJunction(numTerminals = 3) // j2
             .toAcls() // c3
@@ -256,8 +256,8 @@ class SetDirectionTest {
         //               |                   |
         //               \-c10-21 j11 21-c12-/
         //
-        val n = TestNetworkBuilder
-            .startWithJunction(numTerminals = 1) // j0
+        val n = TestNetworkBuilder()
+            .fromJunction(numTerminals = 1) // j0
             .toAcls() // c1
             .toJunction(numTerminals = 3) // j2
             .toAcls() // c3
@@ -316,8 +316,8 @@ class SetDirectionTest {
         //
         // j0 11--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithJunction(numTerminals = 1, nominalPhases = PhaseCode.AB) // j0
+        val n = TestNetworkBuilder()
+            .fromJunction(numTerminals = 1, nominalPhases = PhaseCode.AB) // j0
             .toAcls(nominalPhases = PhaseCode.B) // c1
             .toAcls(nominalPhases = PhaseCode.A) // c2
             .network
@@ -337,8 +337,8 @@ class SetDirectionTest {
         //
         // j0 11--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithJunction(numTerminals = 1, nominalPhases = PhaseCode.NONE) // j0
+        val n = TestNetworkBuilder()
+            .fromJunction(numTerminals = 1, nominalPhases = PhaseCode.NONE) // j0
             .toAcls(nominalPhases = PhaseCode.NONE) // c1
             .toBreaker(PhaseCode.NONE, isNormallyOpen = true)
             .toAcls(nominalPhases = PhaseCode.NONE) // c2

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseInferrerTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseInferrerTest.kt
@@ -42,8 +42,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABtoBCtoXYtoABC() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.AB)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.AB)
             .toAcls(PhaseCode.BC)
             .toAcls(PhaseCode.XY)
             .toAcls(PhaseCode.ABC)
@@ -73,8 +73,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABNtoBCNtoXYNtoABCN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABN)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABN)
             .toAcls(PhaseCode.BCN)
             .toAcls(PhaseCode.XYN)
             .toAcls(PhaseCode.ABCN)
@@ -104,8 +104,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testBCtoACtoXYtoABC() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.BC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.BC)
             .toAcls(PhaseCode.AC)
             .toAcls(PhaseCode.XY)
             .toAcls(PhaseCode.ABC)
@@ -136,8 +136,8 @@ class PhaseInferrerTest {
     @Test
     internal fun testABCtoXYNtoXYtoBC() {
         Tracing.normalPhaseTrace()
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.XYN)
             .toAcls(PhaseCode.XY)
             .toAcls(PhaseCode.BC)
@@ -168,8 +168,8 @@ class PhaseInferrerTest {
     @Test
     internal fun testABCtoXYtoXYNtoBC() {
         Tracing.normalPhaseTrace()
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.XY)
             .toAcls(PhaseCode.XYN)
             .toAcls(PhaseCode.BC)
@@ -199,8 +199,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABCtoNtoABCN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.ABC)
             .toAcls(PhaseCode.N)
             .toAcls(PhaseCode.ABCN)
@@ -232,8 +232,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABCtoBtoXYN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.ABC)
             .toAcls(PhaseCode.B)
             .toAcls(PhaseCode.XYN)
@@ -265,8 +265,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABCtoCtoXYN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.ABC)
             .toAcls(PhaseCode.C)
             .toAcls(PhaseCode.XYN)
@@ -296,8 +296,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABCtoAtoXN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.ABC)
             .toAcls(PhaseCode.A)
             .toAcls(PhaseCode.XN)
@@ -327,8 +327,8 @@ class PhaseInferrerTest {
     //
     @Test
     fun testDualFeedANtoABCN() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.AN)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.AN)
             .toAcls(PhaseCode.ABCN)
             .toSource(PhaseCode.AN)
             .build()
@@ -357,8 +357,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testABCNtoNtoABtoXY() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABCN)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABCN)
             .toAcls(PhaseCode.ABCN)
             .toAcls(PhaseCode.N)
             .toAcls(PhaseCode.AB)
@@ -391,8 +391,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun testWithOpenSwitch() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC)
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC)
             .toAcls(PhaseCode.ABC)
             .toBreaker(PhaseCode.ABC, isNormallyOpen = true)
             .toAcls(PhaseCode.ABC)
@@ -424,8 +424,8 @@ class PhaseInferrerTest {
     //
     @Test
     internal fun validateDirectionsWithDroppedDirectionLoop() {
-        val network = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC) // s0
+        val network = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC) // s0
             .toAcls(PhaseCode.ABC) // c1
             .toAcls(PhaseCode.XY) // c2
             .toAcls(PhaseCode.ABC) // c3

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/RemovePhasesTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/RemovePhasesTest.kt
@@ -32,8 +32,8 @@ class RemovePhasesTest {
     //
     // s4 --c5--
     //
-    val n = TestNetworkBuilder
-        .startWithSource(PhaseCode.ABCN) // s0
+    val n = TestNetworkBuilder()
+        .fromSource(PhaseCode.ABCN) // s0
         .toAcls(PhaseCode.ABCN) // c1
         .toAcls(PhaseCode.ABCN) // c2
         .branchFrom("c1")

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/SetPhasesTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/SetPhasesTest.kt
@@ -68,8 +68,8 @@ class SetPhasesTest {
         //
         // 1--c4--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABCN) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABCN) // s0
             .toAcls(PhaseCode.ABCN) // c1
             .toAcls(PhaseCode.ABCN) // c2
             .branchFrom("c1")
@@ -91,8 +91,8 @@ class SetPhasesTest {
         //
         // s3 11 b4 21--c5--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABCN) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABCN) // s0
             .toBreaker(PhaseCode.ABCN, isNormallyOpen = true, isOpen = false) // b1
             .toAcls(PhaseCode.ABCN) // c2
             .fromSource(PhaseCode.ABCN) // s3
@@ -117,8 +117,8 @@ class SetPhasesTest {
         //
         // s0 11 b1 21--c2--1
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABCN) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABCN) // s0
             .toBreaker(PhaseCode.ABCN) {
                 setOpen(true, SPK.A)
                 setNormallyOpen(true, SPK.B)
@@ -138,8 +138,8 @@ class SetPhasesTest {
         //
         // 1--c0--21--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithAcls(PhaseCode.ABCN) // c0
+        val n = TestNetworkBuilder()
+            .fromAcls(PhaseCode.ABCN) // c0
             .toAcls(PhaseCode.ABCN) // c1
             .toAcls(PhaseCode.ABCN) // c2
             .buildAndLog()
@@ -156,8 +156,8 @@ class SetPhasesTest {
         //
         // 1--c0--21--c1--2
         //
-        val n = TestNetworkBuilder
-            .startWithAcls(PhaseCode.A) // c0
+        val n = TestNetworkBuilder()
+            .fromAcls(PhaseCode.A) // c0
             .toAcls(PhaseCode.A) // c1
             .buildAndLog()
 
@@ -175,8 +175,8 @@ class SetPhasesTest {
         //
         // 1--c0--21--c1--2
         //
-        val n = TestNetworkBuilder
-            .startWithAcls(PhaseCode.A) { terminals[1].normalPhases[SPK.A] = SPK.A } // c0
+        val n = TestNetworkBuilder()
+            .fromAcls(PhaseCode.A) { terminals[1].normalPhases[SPK.A] = SPK.A } // c0
             .toAcls(PhaseCode.A) { terminals[1].normalPhases[SPK.A] = SPK.B } // c1
             .buildAndLog()
 
@@ -197,8 +197,8 @@ class SetPhasesTest {
         //
         // 1--c0--21--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithAcls(PhaseCode.A) { terminals[1].normalPhases[SPK.A] = SPK.A } // c0
+        val n = TestNetworkBuilder()
+            .fromAcls(PhaseCode.A) { terminals[1].normalPhases[SPK.A] = SPK.A } // c0
             .toAcls(PhaseCode.A) // c1
             .toAcls(PhaseCode.A) { terminals[0].normalPhases[SPK.A] = SPK.B } // c2
             .buildAndLog()
@@ -221,8 +221,8 @@ class SetPhasesTest {
         //
         // s0 11--tx1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC) // s0
             .toPowerTransformer(listOf(PhaseCode.ABC, PhaseCode.ABCN)) // tx1
             .toAcls(PhaseCode.ABCN) // c2
             .buildAndLog()
@@ -237,8 +237,8 @@ class SetPhasesTest {
         //
         // s0 11--tx1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.BC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.BC) // s0
             .toPowerTransformer(listOf(PhaseCode.BC, PhaseCode.XN)) // tx1
             .toAcls(PhaseCode.XN) // c2
             .buildAndLog()
@@ -253,8 +253,8 @@ class SetPhasesTest {
         //
         // s0 11--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.BC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.BC) // s0
             .toAcls(PhaseCode.BC) // c1
             .toAcls(PhaseCode.XY) // c2
             .buildAndLog()
@@ -269,8 +269,8 @@ class SetPhasesTest {
         //
         // s0 11--c1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.CN) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.CN) // s0
             .toAcls(PhaseCode.CN) // c1
             .toAcls(PhaseCode.XN) // c2
             .buildAndLog()
@@ -285,8 +285,8 @@ class SetPhasesTest {
         //
         // s0 11--tx1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.AC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.AC) // s0
             .toPowerTransformer(listOf(PhaseCode.AC, PhaseCode.X)) // tx1
             .toAcls(PhaseCode.X) // c2
             .buildAndLog()
@@ -301,8 +301,8 @@ class SetPhasesTest {
         //
         // s0 11--tx1--21--c2--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.AC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.AC) // s0
             .toPowerTransformer(listOf(PhaseCode.AC, PhaseCode.CN)) // tx1
             .toAcls(PhaseCode.CN) // c2
             .buildAndLog()
@@ -321,8 +321,8 @@ class SetPhasesTest {
         //    2              1
         //    1--c2--21--c3--2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC) // s0
             .toPowerTransformer(listOf(PhaseCode.ABC, PhaseCode.ABCN)) // tx1
             .toAcls(PhaseCode.ABCN) // c2
             .toAcls(PhaseCode.CN) // c3
@@ -346,8 +346,8 @@ class SetPhasesTest {
         // s0 1         c2
         //    2 tx3 12--/
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC) // s0
             .toPowerTransformer(listOf(PhaseCode.XY, PhaseCode.XN)) // tx1
             .toAcls(PhaseCode.XN) // c2
             .toPowerTransformer(listOf(PhaseCode.XN, PhaseCode.XY)) // tx3
@@ -365,8 +365,8 @@ class SetPhasesTest {
         //
         // s0 11 tx1 21--c2--21 tx3 2
         //
-        val n = TestNetworkBuilder
-            .startWithSource(PhaseCode.ABC) // s0
+        val n = TestNetworkBuilder()
+            .fromSource(PhaseCode.ABC) // s0
             .toPowerTransformer(listOf(PhaseCode.XY, PhaseCode.XN)) // tx1
             .toAcls(PhaseCode.XN) // c2
             .toPowerTransformer(listOf(PhaseCode.XN, PhaseCode.XY)) // tx3


### PR DESCRIPTION
* Changed `TestNetworkBuilder` to have a public constructor and removed `startWith*` functions. Change `TestNetworkBuilder.startWith*` to `TestNetworkBuilder().from*` _(kotlin)_, or `new TestNetworkBuilder().from*` _(java)_.

* Changed `TestNetworkBuilder.fromOther` and `TestNetworkBuilder.toOther` to take a creator, rather than an instance.

Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>