### PR TITLE
Don't apply phases/set direction if loading the database fails

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@
 * None.
 
 ##### Fixes
-* None.
+* Failure when reading in database tables will now cause a short-circuit failure when all tables are loaded rather than after post load processing.
 
 ##### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/DatabaseReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/DatabaseReader.kt
@@ -96,7 +96,7 @@ class DatabaseReader @JvmOverloads constructor(
             return false
         }
 
-        return status and postLoad(networkService)
+        return status && postLoad(networkService)
     }
 
     private fun preLoad(): Int? {

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/DatabaseReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/DatabaseReader.kt
@@ -85,18 +85,18 @@ class DatabaseReader @JvmOverloads constructor(
         }
 
         logger.info("Loading from database version v$databaseVersion")
-        val status = try {
+        return try {
             MetadataCollectionReader { getStatement(loadConnection) }.load(metadataReader)
                 && NetworkServiceReader { getStatement(loadConnection) }.load(networkServiceReader)
                 && DiagramServiceReader { getStatement(loadConnection) }.load(diagramServiceReader)
                 && CustomerServiceReader { getStatement(loadConnection) }.load(customerServiceReader)
+                && postLoad(networkService)
         } catch (e: MissingTableConfigException) {
             logger.error("Unable to load database: " + e.message)
+            false
+        } finally {
             closeConnection()
-            return false
         }
-
-        return status && postLoad(networkService)
     }
 
     private fun preLoad(): Int? {
@@ -146,7 +146,6 @@ class DatabaseReader @JvmOverloads constructor(
         validateSources(networkService)
         logger.info("Sources vs feeders validated.")
 
-        closeConnection()
         return true
     }
 


### PR DESCRIPTION
# Description
The kotlin `and` statement doesn't cause a short circuit (wtf) which means we apply phases and direction before we eventually fail, which can be time consuming. This looks like it's possibly quite old from when we converted to kotlin (change is beyond when we squashed history), so I don't think it's intentional as the logs you get from the postLoad steps hide the real causes of failure.
For reference:
```kotlin
    /**
     * Performs a logical `and` operation between this Boolean and the [other] one. Unlike the `&&` operator,
     * this function does not perform short-circuit evaluation. Both `this` and [other] will always be evaluated.
     */
    public infix fun and(other: Boolean): Boolean
```
# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added unit tests / updated existing tests for these changes.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
