### PR TITLE
EWB-1854: Add linked container parameters for getEquipmentContainer(s)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
 
 ##### New Features
 * Added `LvFeeder`, a branch of LV network starting at a distribution substation and continuing until the end of the LV network.
-* Added the following optional arguments to `NetworkConsumerClient().getEquipmentForContainers`:
+* Added the following optional arguments to `NetworkConsumerClient().getEquipment(For)Container(s)`:
   * `includeEnergizingContainers`: Specifies whether to include equipment from containers energizing the ones listed in
     `mRIDs`. This is of the enum type `IncludedEnergizingContainers`, which has three possible values:
     * `EXCLUDE_ENERGIZING_CONTAINERS`: No additional effect (default).

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -73,6 +73,8 @@ class NetworkConsumerClient(
      * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
      *
      * @param equipmentContainer The [EquipmentContainer] to fetch equipment for.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -93,6 +95,8 @@ class NetworkConsumerClient(
      * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
      *
      * @param mRID The mRID of the [EquipmentContainer] to fetch equipment for.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -113,6 +117,8 @@ class NetworkConsumerClient(
      * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
      *
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch equipment for.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -133,6 +139,8 @@ class NetworkConsumerClient(
      * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
      *
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch equipment for.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -299,6 +307,8 @@ class NetworkConsumerClient(
      *
      * @param mRID The mRID of the [EquipmentContainer] to fetch.
      * @param expectedClass The expected type of the fetched container.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] of a [MultiObjectResult]. If successful, containing a map keyed by mRID of all the objects retrieved. If an item couldn't be added to
      * [service], its mRID will be present in [MultiObjectResult.failed].
@@ -308,9 +318,14 @@ class NetworkConsumerClient(
      * - [ClassCastException] if the requested object was of the wrong type.
      */
     @JvmOverloads
-    fun getEquipmentContainer(mRID: String, expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java): GrpcResult<MultiObjectResult> =
+    fun getEquipmentContainer(
+        mRID: String,
+        expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
+        includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+    ): GrpcResult<MultiObjectResult> =
         tryRpc {
-            val result = getEquipmentContainers(sequenceOf(mRID), expectedClass)
+            val result = getEquipmentContainers(sequenceOf(mRID), expectedClass, includeEnergizingContainers, includeEnergizedContainers)
             if (result.wasFailure)
                 throw result.thrown
 
@@ -328,6 +343,8 @@ class NetworkConsumerClient(
      *
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch.
      * @param expectedClass The expected type of the fetched containers.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] of a [MultiObjectResult]. If successful, containing a map keyed by mRID of all the objects retrieved. If an item was not found, or
      * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed]
@@ -337,8 +354,10 @@ class NetworkConsumerClient(
      */
     fun getEquipmentContainers(
         mRIDs: Iterable<String>,
-        expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java
-    ): GrpcResult<MultiObjectResult> = getEquipmentContainers(mRIDs.asSequence(), expectedClass)
+        expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
+        includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+    ): GrpcResult<MultiObjectResult> = getEquipmentContainers(mRIDs.asSequence(), expectedClass, includeEnergizingContainers, includeEnergizedContainers)
 
     /***
      * Retrieve the equipment container networks for the specified [mRID]s and store the results in the [service].
@@ -348,6 +367,8 @@ class NetworkConsumerClient(
      *
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch.
      * @param expectedClass The expected type of the fetched containers.
+     * @param includeEnergizingContainers The level of energizing containers to include equipment from.
+     * @param includeEnergizedContainers The level of energized containers to include equipment from.
      *
      * @return A [GrpcResult] of a [MultiObjectResult]. If successful, containing a map keyed by mRID of all the objects retrieved. If an item was not found, or
      * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed]
@@ -357,9 +378,11 @@ class NetworkConsumerClient(
      */
     fun getEquipmentContainers(
         mRIDs: Sequence<String>,
-        expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java
+        expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
+        includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
     ): GrpcResult<MultiObjectResult> = getWithReferences(mRIDs, expectedClass) { it, mor ->
-        mor.objects.putAll(getEquipmentForContainers(it.map { eq -> eq.mRID })
+        mor.objects.putAll(getEquipmentForContainers(it.map { eq -> eq.mRID }, includeEnergizingContainers, includeEnergizedContainers)
             .onError { thrown, wasHandled -> return@getWithReferences GrpcResult.ofError(thrown, wasHandled) }
             .value.objects
         )
@@ -679,6 +702,10 @@ class NetworkConsumerClient(
 
 }
 
-inline fun <reified T : EquipmentContainer> NetworkConsumerClient.getEquipmentContainer(mRID: String): GrpcResult<MultiObjectResult> {
-    return getEquipmentContainer(mRID, T::class.java)
+inline fun <reified T : EquipmentContainer> NetworkConsumerClient.getEquipmentContainer(
+    mRID: String,
+    includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+    includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+): GrpcResult<MultiObjectResult> {
+    return getEquipmentContainer(mRID, T::class.java, includeEnergizingContainers, includeEnergizedContainers)
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -704,7 +704,6 @@ class NetworkConsumerClient(
 
 }
 
-@JvmOverloads
 inline fun <reified T : EquipmentContainer> NetworkConsumerClient.getEquipmentContainer(
     mRID: String,
     includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -352,6 +352,7 @@ class NetworkConsumerClient(
      * In addition to normal gRPC errors, you may also receive an unsuccessful [GrpcResult] with the following errors:
      * - [ClassCastException] if the requested object was of the wrong type.
      */
+    @JvmOverloads
     fun getEquipmentContainers(
         mRIDs: Iterable<String>,
         expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
@@ -376,6 +377,7 @@ class NetworkConsumerClient(
      * In addition to normal gRPC errors, you may also receive an unsuccessful [GrpcResult] with the following errors:
      * - [ClassCastException] if the requested object was of the wrong type.
      */
+    @JvmOverloads
     fun getEquipmentContainers(
         mRIDs: Sequence<String>,
         expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
@@ -702,6 +704,7 @@ class NetworkConsumerClient(
 
 }
 
+@JvmOverloads
 inline fun <reified T : EquipmentContainer> NetworkConsumerClient.getEquipmentContainer(
     mRID: String,
     includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -616,6 +616,29 @@ internal class NetworkConsumerClientTest {
             .withMessage("Unable to extract Circuit networks from [${expectedService.get<Feeder>("f001")?.typeNameAndMRID()}].")
     }
 
+    @Test
+    internal fun `generic get equipment container calls java interop`() {
+        val result = mock<GrpcResult<MultiObjectResult>>()
+
+        doReturn(result).`when`(consumerClient).getEquipmentContainer(any(), any(), any(), any())
+
+        assertThat(
+            consumerClient.getEquipmentContainer<Feeder>(
+                "fdr",
+                IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS,
+                IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS
+            ),
+            equalTo(result)
+        )
+
+        verify(consumerClient).getEquipmentContainer(
+            "fdr",
+            Feeder::class.java,
+            IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS,
+            IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS
+        )
+    }
+
     private fun createResponse(
         identifiedObjectBuilder: NIO.Builder,
         subClassBuilder: (NIO.Builder) -> Any,

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -435,16 +435,6 @@ internal class NetworkConsumerClientTest {
     }
 
     @Test
-    internal fun `get equipment containers sequence variant coverage`() {
-        val expectedResult = mock<GrpcResult<MultiObjectResult>>()
-        doReturn(expectedResult).`when`(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
-
-        assertThat(consumerClient.getEquipmentContainers(sequenceOf("f001")), equalTo(expectedResult))
-
-        verify(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
-    }
-
-    @Test
     internal fun `getIdentifiedObjects returns failed mRID when an mRID is not found`() {
         val mRIDs = listOf("id1", "id2")
 
@@ -542,11 +532,13 @@ internal class NetworkConsumerClientTest {
         val connectivityNode = ConnectivityNode()
 
         doReturn(expectedResult).`when`(consumerClient).getEquipmentForContainer(eq(feeder.mRID), any(), any())
+        doReturn(expectedResult).`when`(consumerClient).getEquipmentContainer(eq(feeder.mRID), any(), any(), any())
         doReturn(expectedResult).`when`(consumerClient).getEquipmentForRestriction(eq(operationalRestriction.mRID))
         doReturn(expectedResult).`when`(consumerClient).getCurrentEquipmentForFeeder(eq(feeder.mRID))
         doReturn(expectedResult).`when`(consumerClient).getTerminalsForConnectivityNode(eq(connectivityNode.mRID))
 
         assertThat(consumerClient.getEquipmentForContainer(feeder), equalTo(expectedResult))
+        assertThat(consumerClient.getEquipmentContainer(feeder.mRID), equalTo(expectedResult))
         assertThat(consumerClient.getEquipmentForRestriction(operationalRestriction), equalTo(expectedResult))
         assertThat(consumerClient.getCurrentEquipmentForFeeder(feeder), equalTo(expectedResult))
         assertThat(consumerClient.getTerminalsForConnectivityNode(connectivityNode), equalTo(expectedResult))

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -547,13 +547,13 @@ internal class NetworkConsumerClientTest {
         val result1 = mock<GrpcResult<MultiObjectResult>>()
         val result2 = mock<GrpcResult<MultiObjectResult>>()
 
-        doReturn(result1).`when`(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any())
+        doReturn(result1).`when`(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
         doReturn(result2).`when`(consumerClient).getEquipmentForContainers(any<Sequence<String>>(), any(), any())
 
         assertThat(consumerClient.getEquipmentContainers(listOf("id")), equalTo(result1))
         assertThat(consumerClient.getEquipmentForContainers(listOf("id")), equalTo(result2))
 
-        verify(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any())
+        verify(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
         verify(consumerClient).getEquipmentForContainers(any<Sequence<String>>(), any(), any())
     }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -435,6 +435,16 @@ internal class NetworkConsumerClientTest {
     }
 
     @Test
+    internal fun `get equipment containers sequence variant coverage`() {
+        val expectedResult = mock<GrpcResult<MultiObjectResult>>()
+        doReturn(expectedResult).`when`(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
+
+        assertThat(consumerClient.getEquipmentContainers(sequenceOf("f001")), equalTo(expectedResult))
+
+        verify(consumerClient).getEquipmentContainers(any<Sequence<String>>(), any(), any(), any())
+    }
+
+    @Test
     internal fun `getIdentifiedObjects returns failed mRID when an mRID is not found`() {
         val mRIDs = listOf("id1", "id2")
 


### PR DESCRIPTION
# Description

The functions that wrap `getEquipmentForContainers`, named `getEquipmentContainer(s)`, provide more helpful HTTP error codes and reponses. This PR adds the same functionality that was added in https://github.com/zepben/evolve-sdk-jvm/pull/110 for these functions.

# Associated tasks:

- This task blocks https://github.com/zepben/feeder-load-analysis/pull/3 from merging.

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes if they are necessary.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
