### PR TITLE
Ewb 1930 support yyn tx

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Changed the minimum supported database version to v43.
 
 ##### New Features
+* Added support for YYN single phase transformers when determining phases.
 * Added `LvFeeder`, a branch of LV network starting at a distribution substation and continuing until the end of the LV network.
 * Added the following optional arguments to `NetworkConsumerClient().getEquipment(For)Container(s)`:
   * `includeEnergizingContainers`: Specifies whether to include equipment from containers energizing the ones listed in

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
@@ -83,21 +83,21 @@ object TransformerPhasePaths {
         ),
         PhaseCode.ABN to mapOf(
             PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.N, SPK.N)),
-            PhaseCode.XYN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.B, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
-            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B)),
+            PhaseCode.XY to listOf(path(SPK.A, SPK.X), path(SPK.B, SPK.Y)),
         ),
         PhaseCode.BCN to mapOf(
             PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
-            PhaseCode.XYN to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.B, SPK.X), path(SPK.C, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
-            PhaseCode.XY to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C)),
+            PhaseCode.XY to listOf(path(SPK.B, SPK.X), path(SPK.C, SPK.Y)),
         ),
         PhaseCode.ACN to mapOf(
             PhaseCode.ACN to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
-            PhaseCode.XYN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.C, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
-            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
+            PhaseCode.XY to listOf(path(SPK.A, SPK.X), path(SPK.C, SPK.Y)),
         ),
         PhaseCode.XYN to mapOf(
             PhaseCode.ABN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), path(SPK.N, SPK.N)),

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
@@ -67,6 +67,7 @@ object TransformerPhasePaths {
             PhaseCode.ABC to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
         ),
         PhaseCode.AB to mapOf(
+            PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), addNeutral),
             PhaseCode.AN to listOf(path(SPK.A, SPK.A), addNeutral),
             PhaseCode.XN to listOf(path(SPK.A, SPK.X), addNeutral),
             PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
@@ -75,6 +76,7 @@ object TransformerPhasePaths {
             PhaseCode.X to listOf(path(SPK.A, SPK.X)),
         ),
         PhaseCode.BC to mapOf(
+            PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C), addNeutral),
             PhaseCode.BN to listOf(path(SPK.B, SPK.B), addNeutral),
             PhaseCode.XN to listOf(path(SPK.B, SPK.X), addNeutral),
             PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
@@ -83,6 +85,7 @@ object TransformerPhasePaths {
             PhaseCode.X to listOf(path(SPK.B, SPK.X)),
         ),
         PhaseCode.AC to mapOf(
+            PhaseCode.ACN to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C), addNeutral),
             PhaseCode.CN to listOf(path(SPK.C, SPK.C), addNeutral),
             PhaseCode.XN to listOf(path(SPK.C, SPK.X), addNeutral),
             PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
@@ -91,6 +94,7 @@ object TransformerPhasePaths {
             PhaseCode.X to listOf(path(SPK.C, SPK.X)),
         ),
         PhaseCode.XY to mapOf(
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y), addNeutral),
             PhaseCode.AN to listOf(path(SPK.X, SPK.A), addNeutral),
             PhaseCode.BN to listOf(path(SPK.X, SPK.B), addNeutral),
             PhaseCode.CN to listOf(path(SPK.X, SPK.C), addNeutral),

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
@@ -66,8 +66,24 @@ object TransformerPhasePaths {
             PhaseCode.ABCN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.C, SPK.C), addNeutral),
             PhaseCode.ABC to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
         ),
+        PhaseCode.ABN to mapOf(
+            PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
+            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B)),
+        ),
+        PhaseCode.ACN to mapOf(
+            PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
+            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
+        ),
+        PhaseCode.BCN to mapOf(
+            PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
+            PhaseCode.XY to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C)),
+        ),
+        PhaseCode.XYN to mapOf(
+            PhaseCode.XY to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y)),
+        ),
         PhaseCode.AB to mapOf(
             PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.B, SPK.Y), addNeutral),
             PhaseCode.AN to listOf(path(SPK.A, SPK.A), addNeutral),
             PhaseCode.XN to listOf(path(SPK.A, SPK.X), addNeutral),
             PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
@@ -77,6 +93,7 @@ object TransformerPhasePaths {
         ),
         PhaseCode.BC to mapOf(
             PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.B, SPK.X), path(SPK.C, SPK.Y), addNeutral),
             PhaseCode.BN to listOf(path(SPK.B, SPK.B), addNeutral),
             PhaseCode.XN to listOf(path(SPK.B, SPK.X), addNeutral),
             PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
@@ -86,6 +103,7 @@ object TransformerPhasePaths {
         ),
         PhaseCode.AC to mapOf(
             PhaseCode.ACN to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.C, SPK.Y), addNeutral),
             PhaseCode.CN to listOf(path(SPK.C, SPK.C), addNeutral),
             PhaseCode.XN to listOf(path(SPK.C, SPK.X), addNeutral),
             PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
@@ -9,6 +9,7 @@
 package com.zepben.evolve.services.network.tracing.connectivity
 
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.services.network.tracing.phases.NominalPhasePath
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind as SPK
 
@@ -19,6 +20,20 @@ object TransformerPhasePaths {
     // THis is used to indicate that a transformer adds a neutral and it should be energised from the transformer.
     private val addNeutral = path(SPK.NONE, SPK.N)
 
+    /**
+     * A lookup of the valid phase paths through a [PowerTransformer]. The first index of the lookup is the "from terminal" phases, the second is the
+     * "to terminal" phases, which then returns a list of phase paths if it is valid.
+     *
+     * NOTE: These do not currently check the [PowerTransformer.vectorGroup] for valid subsets of these paths, so may produce unexpected results in edge cases.
+     *
+     * These are logical connections between the phases on different terminals of a transformer, and use a nominal phase naming convention when producing
+     * secondary phases e.g. `AB -> AN` in a DYn transformer. In these cases, only the phase with a matching name on each side will have a complete path. e.g.
+     * `A -> A`, `B` will be dropped.
+     *
+     * If a phase is added by the transformer, and should be considered "energised", it will be included in the path with `NONE` from phase. e.g. If you are
+     * moving in the `AB -> AN` direction, you will have a path of `NONE -> N`, and if you are moving in the `AN -> AB` direction, you will have a path of
+     * `NONE -> B`
+     */
     val lookup: Map<PhaseCode, Map<PhaseCode, List<NominalPhasePath>>> = mapOf(
         PhaseCode.ABCN to mapOf(
             PhaseCode.ABCN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
@@ -67,18 +82,31 @@ object TransformerPhasePaths {
             PhaseCode.ABC to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
         ),
         PhaseCode.ABN to mapOf(
+            PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), path(SPK.N, SPK.N)),
             PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
             PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B)),
         ),
-        PhaseCode.ACN to mapOf(
-            PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
-            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
-        ),
         PhaseCode.BCN to mapOf(
+            PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
             PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
             PhaseCode.XY to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C)),
         ),
+        PhaseCode.ACN to mapOf(
+            PhaseCode.ACN to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
+            PhaseCode.XY to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
+        ),
         PhaseCode.XYN to mapOf(
+            PhaseCode.ABN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), path(SPK.N, SPK.N)),
+            PhaseCode.BCN to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.ACN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C), path(SPK.N, SPK.N)),
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y), path(SPK.N, SPK.N)),
+            PhaseCode.AB to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B)),
+            PhaseCode.BC to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C)),
+            PhaseCode.AC to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
             PhaseCode.XY to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y)),
         ),
         PhaseCode.AB to mapOf(
@@ -112,6 +140,9 @@ object TransformerPhasePaths {
             PhaseCode.X to listOf(path(SPK.C, SPK.X)),
         ),
         PhaseCode.XY to mapOf(
+            PhaseCode.ABN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), addNeutral),
+            PhaseCode.BCN to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C), addNeutral),
+            PhaseCode.ACN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C), addNeutral),
             PhaseCode.XYN to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y), addNeutral),
             PhaseCode.AN to listOf(path(SPK.X, SPK.A), addNeutral),
             PhaseCode.BN to listOf(path(SPK.X, SPK.B), addNeutral),

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
@@ -50,6 +50,31 @@ internal class TerminalConnectivityInternalTest {
     }
 
     @Test
+    internal fun pathsThroughHv2Lv2Tx() {
+        validateTxPaths(PhaseCode.AB, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.AB, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.AC, PhaseCode.ACN)
+        validateTxPaths(PhaseCode.AC, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.BC, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.BC, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.XY, PhaseCode.XYN)
+    }
+
+    @Test
+    internal fun pathsThroughLv2Hv2Tx() {
+        validateTxPaths(PhaseCode.ABN, PhaseCode.AB)
+
+        validateTxPaths(PhaseCode.ACN, PhaseCode.AC)
+
+        validateTxPaths(PhaseCode.BCN, PhaseCode.BC)
+
+        validateTxPaths(PhaseCode.XYN, PhaseCode.XY)
+    }
+
+    @Test
     internal fun pathsThroughHv1Lv1Tx() {
         validateTxPaths(PhaseCode.AB, PhaseCode.AN)
         validateTxPaths(PhaseCode.AB, PhaseCode.BN, PhaseCode.NONE)

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
@@ -50,28 +50,26 @@ internal class TerminalConnectivityInternalTest {
     }
 
     @Test
-    internal fun pathsThroughHv2Lv2Tx() {
+    internal fun pathsThroughHv1Lv2Tx() {
         validateTxPaths(PhaseCode.AB, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.AB, PhaseCode.BCN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.AB, PhaseCode.ACN, PhaseCode.NONE)
         validateTxPaths(PhaseCode.AB, PhaseCode.XYN)
 
+        validateTxPaths(PhaseCode.BC, PhaseCode.ABN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BC, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.BC, PhaseCode.ACN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BC, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.AC, PhaseCode.ABN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.AC, PhaseCode.BCN, PhaseCode.NONE)
         validateTxPaths(PhaseCode.AC, PhaseCode.ACN)
         validateTxPaths(PhaseCode.AC, PhaseCode.XYN)
 
-        validateTxPaths(PhaseCode.BC, PhaseCode.BCN)
-        validateTxPaths(PhaseCode.BC, PhaseCode.XYN)
-
+        validateTxPaths(PhaseCode.XY, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.XY, PhaseCode.ACN)
+        validateTxPaths(PhaseCode.XY, PhaseCode.BCN)
         validateTxPaths(PhaseCode.XY, PhaseCode.XYN)
-    }
-
-    @Test
-    internal fun pathsThroughLv2Hv2Tx() {
-        validateTxPaths(PhaseCode.ABN, PhaseCode.AB)
-
-        validateTxPaths(PhaseCode.ACN, PhaseCode.AC)
-
-        validateTxPaths(PhaseCode.BCN, PhaseCode.BC)
-
-        validateTxPaths(PhaseCode.XYN, PhaseCode.XY)
     }
 
     @Test
@@ -95,6 +93,45 @@ internal class TerminalConnectivityInternalTest {
         validateTxPaths(PhaseCode.XY, PhaseCode.BN)
         validateTxPaths(PhaseCode.XY, PhaseCode.CN)
         validateTxPaths(PhaseCode.XY, PhaseCode.XN)
+    }
+
+    @Test
+    internal fun pathsThroughLv2Lv2Tx() {
+        validateTxPaths(PhaseCode.ABN, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.ACN)
+
+        validateTxPaths(PhaseCode.ABN, PhaseCode.XYN)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.XYN)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.XYN, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.ACN)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.XYN)
+    }
+
+    @Test
+    internal fun pathsThroughLv2Hv1Tx() {
+        validateTxPaths(PhaseCode.ABN, PhaseCode.AB)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.BC, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.AC, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.XY)
+
+        validateTxPaths(PhaseCode.BCN, PhaseCode.AB, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.BC)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.AC, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.XY)
+
+        validateTxPaths(PhaseCode.ACN, PhaseCode.AB, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.BC, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.AC)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.XY)
+
+        validateTxPaths(PhaseCode.XYN, PhaseCode.AB)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.BC)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.AC)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.XY)
     }
 
     @Test


### PR DESCRIPTION
# Description

Adding support when setting phases for YYN single phase transformers. This isn't complete and still needs tests, and needs to be run over other networks. It works for endeavours network, however I haven't yet checked if it breaks other networks.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
