### PR TITLE
EWB-1354: Fix impedance calculation from short circuit test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 
 ##### Fixes
 * Failure when reading in database tables will now cause a short-circuit failure when all tables are loaded rather than after post load processing.
+* Corrected function that calculates the equivalent impedance of a transformer from the results of a short circuit test.
 
 ##### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfo.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfo.kt
@@ -82,9 +82,9 @@ class TransformerEndInfo(mRID: String = "") : AssetInfo(mRID) {
             // only the wattmeter reading and either the voltmeter or ampmeter reading is needed for all calculations.
             val (voltage, current) = shortCircuitTest?.voltage?.let {
                 val v = (it / 100) * rU
-                v to rS / v
+                Pair(v, rS / v)
             } ?: shortCircuitTest?.current?.let {
-                rS / it to it
+                Pair(rS / it, it)
             } ?: return Pair(null, null)
 
             val r = shortCircuitTest?.voltageOhmicPart?.let {

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
@@ -127,6 +127,7 @@ internal class TransformerEndInfoTest {
         val ohmicAndCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; current = 34388.19 }
         val ohmicNoVoltageOrCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147 }
         val voltageOnlyTest = ShortCircuitTest().apply { voltage = 11.85 }
+        val currentOnlyTest = ShortCircuitTest().apply { current = 34388.19 }
 
         // check via loss
         validateResistanceReactanceFromTest(400000, 1630000000, lossAndVoltageTest, lossAndVoltageTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
@@ -160,6 +161,7 @@ internal class TransformerEndInfoTest {
 
         // check invalid
         validateResistanceReactanceFromTest(400000, 1630000000, voltageOnlyTest, voltageOnlyTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, currentOnlyTest, currentOnlyTest, null)
     }
 
     private fun validateResistanceReactanceFromTest(

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
@@ -120,27 +120,43 @@ internal class TransformerEndInfoTest {
 
     @Test
     internal fun testCalculatesResistanceReactanceOfEndInfoTestsIfAvailable() {
-        val lossTest = ShortCircuitTest().apply { loss = 20201800; voltage = 11.85 }
-        val lossNoVoltageTest = ShortCircuitTest().apply { loss = 20201800 }
-        val ohmicTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; voltage = 11.85 }
-        val ohmicNoVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147 }
+        val lossAndVoltageTest = ShortCircuitTest().apply { loss = 20201800; voltage = 11.85 }
+        val lossAndCurrentTest = ShortCircuitTest().apply { loss = 20201800; current = 34388.19 }
+        val lossNoVoltageOrCurrentTest = ShortCircuitTest().apply { loss = 20201800 }
+        val ohmicAndVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; voltage = 11.85 }
+        val ohmicAndCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; current = 34388.19 }
+        val ohmicNoVoltageOrCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147 }
         val voltageOnlyTest = ShortCircuitTest().apply { voltage = 11.85 }
 
         // check via loss
-        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, lossTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, lossTest, lossTest, null)
-        validateResistanceReactanceFromTest(400000, null, lossTest, lossTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, lossTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, null, ResistanceReactance(0.02, 1.38, null, null))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageTest, lossNoVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, lossAndVoltageTest, lossAndVoltageTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
+        validateResistanceReactanceFromTest(null, 1630000000, lossAndVoltageTest, lossAndVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, null, lossAndVoltageTest, lossAndVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, lossAndVoltageTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossAndVoltageTest, null, ResistanceReactance(0.02, 1.38, null, null))
+
+        validateResistanceReactanceFromTest(400000, 1630000000, lossAndCurrentTest, lossAndCurrentTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
+        validateResistanceReactanceFromTest(null, 1630000000, lossAndCurrentTest, lossAndCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, null, lossAndCurrentTest, lossAndCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, lossAndCurrentTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossAndCurrentTest, null, ResistanceReactance(0.02, 1.38, null, null))
+
+        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageOrCurrentTest, lossNoVoltageOrCurrentTest, null)
 
         // check via ohmic part
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, ohmicTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, ohmicTest, ohmicTest, null)
-        validateResistanceReactanceFromTest(400000, null, ohmicTest, ohmicTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, null, ResistanceReactance(0.02, 1.38, null, null))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageTest, ohmicNoVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndVoltageTest, ohmicAndVoltageTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
+        validateResistanceReactanceFromTest(null, 1630000000, ohmicAndVoltageTest, ohmicAndVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, null, ohmicAndVoltageTest, ohmicAndVoltageTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicAndVoltageTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndVoltageTest, null, ResistanceReactance(0.02, 1.38, null, null))
+
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndCurrentTest, ohmicAndCurrentTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
+        validateResistanceReactanceFromTest(null, 1630000000, ohmicAndCurrentTest, ohmicAndCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, null, ohmicAndCurrentTest, ohmicAndCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicAndCurrentTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndCurrentTest, null, ResistanceReactance(0.02, 1.38, null, null))
+
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageOrCurrentTest, ohmicNoVoltageOrCurrentTest, null)
 
         // check invalid
         validateResistanceReactanceFromTest(400000, 1630000000, voltageOnlyTest, voltageOnlyTest, null)

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
@@ -120,48 +120,34 @@ internal class TransformerEndInfoTest {
 
     @Test
     internal fun testCalculatesResistanceReactanceOfEndInfoTestsIfAvailable() {
-        val lossAndVoltageTest = ShortCircuitTest().apply { loss = 20201800; voltage = 11.85 }
-        val lossAndCurrentTest = ShortCircuitTest().apply { loss = 20201800; current = 34388.19 }
-        val lossNoVoltageOrCurrentTest = ShortCircuitTest().apply { loss = 20201800 }
-        val ohmicAndVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; voltage = 11.85 }
-        val ohmicAndCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; current = 34388.19 }
-        val ohmicNoVoltageOrCurrentTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147 }
+        val lossTest = ShortCircuitTest().apply { loss = 2020180; voltage = 11.85 }
+        val lossNoVoltageTest = ShortCircuitTest().apply { loss = 2020180 }
+        val lossTestWithCurrent = ShortCircuitTest().apply { loss = 2020180; voltage = 11.85; current = 4075.0 }
+        val ohmicTest = ShortCircuitTest().apply { voltageOhmicPart = 0.124; voltage = 11.85 }
+        val ohmicNoVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.124 }
+        val ohmicTestWithCurrent = ShortCircuitTest().apply { voltageOhmicPart = 0.124; voltage = 11.85; current = 4075.0 }
         val voltageOnlyTest = ShortCircuitTest().apply { voltage = 11.85 }
-        val currentOnlyTest = ShortCircuitTest().apply { current = 34388.19 }
 
         // check via loss
-        validateResistanceReactanceFromTest(400000, 1630000000, lossAndVoltageTest, lossAndVoltageTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, lossAndVoltageTest, lossAndVoltageTest, null)
-        validateResistanceReactanceFromTest(400000, null, lossAndVoltageTest, lossAndVoltageTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, lossAndVoltageTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossAndVoltageTest, null, ResistanceReactance(0.02, 1.38, null, null))
-
-        validateResistanceReactanceFromTest(400000, 1630000000, lossAndCurrentTest, lossAndCurrentTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, lossAndCurrentTest, lossAndCurrentTest, null)
-        validateResistanceReactanceFromTest(400000, null, lossAndCurrentTest, lossAndCurrentTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, lossAndCurrentTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossAndCurrentTest, null, ResistanceReactance(0.02, 1.38, null, null))
-
-        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageOrCurrentTest, lossNoVoltageOrCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, lossTest, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
+        validateResistanceReactanceFromTest(null, 1630000000, lossTest, lossTest, null)
+        validateResistanceReactanceFromTest(400000, null, lossTest, lossTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, lossTest, ResistanceReactance(null, null, 0.12, 11.63))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, null, ResistanceReactance(0.12, 11.63, null, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageTest, lossNoVoltageTest, ResistanceReactance(0.12, null, 0.12, null))
+        validateResistanceReactanceFromTest(400000, 2000000000, lossTestWithCurrent, lossTestWithCurrent, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
 
         // check via ohmic part
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndVoltageTest, ohmicAndVoltageTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, ohmicAndVoltageTest, ohmicAndVoltageTest, null)
-        validateResistanceReactanceFromTest(400000, null, ohmicAndVoltageTest, ohmicAndVoltageTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicAndVoltageTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndVoltageTest, null, ResistanceReactance(0.02, 1.38, null, null))
-
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndCurrentTest, ohmicAndCurrentTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
-        validateResistanceReactanceFromTest(null, 1630000000, ohmicAndCurrentTest, ohmicAndCurrentTest, null)
-        validateResistanceReactanceFromTest(400000, null, ohmicAndCurrentTest, ohmicAndCurrentTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicAndCurrentTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicAndCurrentTest, null, ResistanceReactance(0.02, 1.38, null, null))
-
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageOrCurrentTest, ohmicNoVoltageOrCurrentTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, ohmicTest, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
+        validateResistanceReactanceFromTest(null, 1630000000, ohmicTest, ohmicTest, null)
+        validateResistanceReactanceFromTest(400000, null, ohmicTest, ohmicTest, null)
+        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicTest, ResistanceReactance(null, null, 0.12, 11.63))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, null, ResistanceReactance(0.12, 11.63, null, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageTest, ohmicNoVoltageTest, ResistanceReactance(0.12, null, 0.12, null))
+        validateResistanceReactanceFromTest(400000, 2000000000, ohmicTestWithCurrent, ohmicTestWithCurrent, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
 
         // check invalid
         validateResistanceReactanceFromTest(400000, 1630000000, voltageOnlyTest, voltageOnlyTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, currentOnlyTest, currentOnlyTest, null)
     }
 
     private fun validateResistanceReactanceFromTest(

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61968/assetinfo/TransformerEndInfoTest.kt
@@ -120,27 +120,27 @@ internal class TransformerEndInfoTest {
 
     @Test
     internal fun testCalculatesResistanceReactanceOfEndInfoTestsIfAvailable() {
-        val lossTest = ShortCircuitTest().apply { loss = 2020180; voltage = 11.85 }
-        val lossNoVoltageTest = ShortCircuitTest().apply { loss = 2020180 }
-        val ohmicTest = ShortCircuitTest().apply { voltageOhmicPart = 0.124; voltage = 11.85 }
-        val ohmicNoVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.124 }
+        val lossTest = ShortCircuitTest().apply { loss = 20201800; voltage = 11.85 }
+        val lossNoVoltageTest = ShortCircuitTest().apply { loss = 20201800 }
+        val ohmicTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147; voltage = 11.85 }
+        val ohmicNoVoltageTest = ShortCircuitTest().apply { voltageOhmicPart = 0.147 }
         val voltageOnlyTest = ShortCircuitTest().apply { voltage = 11.85 }
 
         // check via loss
-        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, lossTest, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, lossTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
         validateResistanceReactanceFromTest(null, 1630000000, lossTest, lossTest, null)
         validateResistanceReactanceFromTest(400000, null, lossTest, lossTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, lossTest, ResistanceReactance(null, null, 0.12, 11.63))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, null, ResistanceReactance(0.12, 11.63, null, null))
-        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageTest, lossNoVoltageTest, ResistanceReactance(0.12, null, 0.12, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, null, lossTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossTest, null, ResistanceReactance(0.02, 1.38, null, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, lossNoVoltageTest, lossNoVoltageTest, null)
 
         // check via ohmic part
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, ohmicTest, ResistanceReactance(0.12, 11.63, 0.12, 11.63))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, ohmicTest, ResistanceReactance(0.02, 1.38, 0.02, 1.38))
         validateResistanceReactanceFromTest(null, 1630000000, ohmicTest, ohmicTest, null)
         validateResistanceReactanceFromTest(400000, null, ohmicTest, ohmicTest, null)
-        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicTest, ResistanceReactance(null, null, 0.12, 11.63))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, null, ResistanceReactance(0.12, 11.63, null, null))
-        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageTest, ohmicNoVoltageTest, ResistanceReactance(0.12, null, 0.12, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, null, ohmicTest, ResistanceReactance(r=null, x=null, r0=0.02, x0=1.38))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicTest, null, ResistanceReactance(0.02, 1.38, null, null))
+        validateResistanceReactanceFromTest(400000, 1630000000, ohmicNoVoltageTest, ohmicNoVoltageTest, null)
 
         // check invalid
         validateResistanceReactanceFromTest(400000, 1630000000, voltageOnlyTest, voltageOnlyTest, null)


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

`calculateRXFromTest` was not using the correct formulas to calculate impedance from a short circuit test. This PR fixes it.
See https://en.wikipedia.org/wiki/Short-circuit_test for the formulas used.

# Associated tasks:

No blocking or blocked tasks.

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
