### PR TITLE
EWB-2251: Add PowerTransformer::getEnd(Terminal)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
     * `PotentialTransformerKind`: The construction kind of the potential transformer. (Enum)
     * `Sensor`: This class describes devices that transform a measured quantity into signals that can be presented at displays,
                 used in control or be recorded.
+* Added `PowerTransformer().getEnd(Terminal)`, which gets a `PowerTransformerEnd` by the `Terminal` it's connected to.
 
 ### Enhancements
 * None.

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformer.kt
@@ -11,6 +11,7 @@ import com.zepben.evolve.cim.iec61968.assetinfo.PowerTransformerInfo
 import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.TransformerConstructionKind
 import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.TransformerFunctionKind
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.services.common.extensions.*
 
 /**
@@ -83,7 +84,7 @@ class PowerTransformer @JvmOverloads constructor(mRID: String = "") : Conducting
     /**
      * Get the number of entries in the [PowerTransformerEnd] collection.
      */
-    fun numEnds() = _powerTransformerEnds?.size ?: 0
+    fun numEnds(): Int = _powerTransformerEnds?.size ?: 0
 
     /**
      * Get a [PowerTransformerEnd] of this [PowerTransformer] by its [PowerTransformerEnd.mRID]
@@ -91,7 +92,7 @@ class PowerTransformer @JvmOverloads constructor(mRID: String = "") : Conducting
      * @param mRID the mRID of the required [PowerTransformerEnd]
      * @return The [PowerTransformerEnd] with the specified [mRID] if it exists, otherwise null
      */
-    fun getEnd(mRID: String) = _powerTransformerEnds.getByMRID(mRID)
+    fun getEnd(mRID: String): PowerTransformerEnd? = _powerTransformerEnds.getByMRID(mRID)
 
     /**
      * Get a [PowerTransformerEnd] of this [PowerTransformer] by its [PowerTransformerEnd.endNumber]
@@ -99,7 +100,15 @@ class PowerTransformer @JvmOverloads constructor(mRID: String = "") : Conducting
      * @param endNumber the end number of the required [PowerTransformerEnd]
      * @return The [PowerTransformerEnd] with the specified [endNumber] if it exists, otherwise null
      */
-    fun getEnd(endNumber: Int) = _powerTransformerEnds?.firstOrNull { it.endNumber == endNumber }
+    fun getEnd(endNumber: Int): PowerTransformerEnd? = _powerTransformerEnds?.firstOrNull { it.endNumber == endNumber }
+
+    /**
+     * Get a [PowerTransformerEnd] of this [PowerTransformer] by its [PowerTransformerEnd.terminal]
+     *
+     * @param terminal the terminal of the required [PowerTransformerEnd]
+     * @return The [PowerTransformerEnd] with the specified [terminal] if it exists, otherwise null
+     */
+    fun getEnd(terminal: Terminal): PowerTransformerEnd? = _powerTransformerEnds?.firstOrNull { it.terminal == terminal }
 
     /**
      * Add a [PowerTransformerEnd] to this [PowerTransformer]

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerTest.kt
@@ -11,6 +11,7 @@ import com.zepben.evolve.cim.iec61968.assetinfo.PowerTransformerInfo
 import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.TransformerConstructionKind
 import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.TransformerFunctionKind
 import com.zepben.evolve.cim.iec61970.base.core.BaseVoltage
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.services.common.extensions.typeNameAndMRID
 import com.zepben.evolve.utils.PrivateCollectionValidator
 import com.zepben.testutils.exception.ExpectException.Companion.expect
@@ -90,6 +91,26 @@ internal class PowerTransformerTest {
             PowerTransformer::removeEnd,
             PowerTransformer::clearEnds
         )
+    }
+
+    @Test
+    internal fun getEndByTerminal() {
+        val t1 = Terminal()
+        val t2 = Terminal()
+        val t3 = Terminal()
+        val e1 = PowerTransformerEnd().apply { terminal = t3 }
+        val e2 = PowerTransformerEnd().apply { terminal = t1 }
+        val pt = PowerTransformer().apply {
+            addTerminal(t1)
+            addTerminal(t2)
+            addTerminal(t3)
+            addEnd(e1)
+            addEnd(e2)
+        }
+
+        assertThat(pt.getEnd(t1), equalTo(e2))
+        assertThat(pt.getEnd(t2), nullValue())
+        assertThat(pt.getEnd(t3), equalTo(e1))
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Adds `PowerTransformer::getEnd(Terminal)`, which gets a `PowerTransformerEnd` associated with the `PowerTransformer` that is connected to the specified `Terminal`.

# Associated tasks:

No blocking nor blocked tasks.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have handled all new warnings generated by the compiler or IDE.
