### PR TITLE
EWB-2538: Fix limited connected trace

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 ### Fixes
 * remove lvfeeder function fixed (previously still adds)
 * remove component test updated to contain another check
+* Fixed bug where limited connected traces with `maximumSteps = 1` could include equipment 2 steps away.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTrace.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTrace.kt
@@ -75,7 +75,7 @@ class LimitedConnectedEquipmentTrace(
                     addStopCondition { (ce, _) -> ce.terminals.none { getTerminalDirection(it) == feederDirection } }
                     addStepAction { matchingEquipment.add(ConductingEquipmentStep(it.conductingEquipment, it.step + 1)) }
 
-                    run(start, false)
+                    run(start)
                 }
             }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTraceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTraceTest.kt
@@ -11,6 +11,7 @@ package com.zepben.evolve.services.network.tracing.connectivity
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.Junction
+import com.zepben.evolve.services.network.tracing.Tracing.normalConnectedEquipmentTrace
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
 import com.zepben.evolve.testing.TestNetworkBuilder
 import com.zepben.testutils.junit.SystemLogExtension
@@ -246,6 +247,23 @@ internal class LimitedConnectedEquipmentTraceTest {
 
         assertThat(results, aMapWithSize(1))
         assertThat(results[ns["j0"]], equalTo(0))
+    }
+
+    @Test
+    internal fun withDirectionCanStopOnStartItem() {
+        val ns = TestNetworkBuilder()
+            .fromJunction(numTerminals = 1) // j0
+            .toAcls() // c1
+            .toJunction(numTerminals = 1) // j2
+            .addFeeder("j0")
+            .build()
+
+        val lcet = LimitedConnectedEquipmentTrace({ normalConnectedEquipmentTrace() }) { it.normalFeederDirection }
+        val results = lcet.run(listOf(ns["j0"]!!), 1, FeederDirection.DOWNSTREAM)
+
+        assertThat(results, aMapWithSize(2))
+        assertThat(results[ns["j0"]], equalTo(0))
+        assertThat(results[ns["c1"]], equalTo(1))
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTraceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/LimitedConnectedEquipmentTraceTest.kt
@@ -142,7 +142,7 @@ internal class LimitedConnectedEquipmentTraceTest {
         trace.run(listOf(simpleNs["b2"]!!), 2, FeederDirection.DOWNSTREAM)
 
         verify(traversal).run(any<ConductingEquipment>(), any())
-        verify(traversal).run(simpleNs["c3"]!!, false)
+        verify(traversal).run(simpleNs["c3"]!!)
     }
 
     @Test
@@ -150,7 +150,7 @@ internal class LimitedConnectedEquipmentTraceTest {
         trace.run(listOf(simpleNs["b2"]!!), 2, FeederDirection.UPSTREAM)
 
         verify(traversal).run(any<ConductingEquipment>(), any())
-        verify(traversal).run(simpleNs["c1"]!!, false)
+        verify(traversal).run(simpleNs["c1"]!!)
     }
 
     @Test
@@ -171,8 +171,8 @@ internal class LimitedConnectedEquipmentTraceTest {
         trace.run(listOf(ns["j2"]!!), 2, FeederDirection.BOTH)
 
         verify(traversal, times(2)).run(any<ConductingEquipment>(), any())
-        verify(traversal).run(ns["c1"]!!, false)
-        verify(traversal).run(ns["c5"]!!, false)
+        verify(traversal).run(ns["c1"]!!)
+        verify(traversal).run(ns["c5"]!!)
     }
 
     @Test
@@ -194,7 +194,7 @@ internal class LimitedConnectedEquipmentTraceTest {
         trace.run(listOf(ns["j2"]!!), 2, FeederDirection.NONE)
 
         verify(traversal).run(any<ConductingEquipment>(), any())
-        verify(traversal).run(ns["c5"]!!, false)
+        verify(traversal).run(ns["c5"]!!)
     }
 
     @Test


### PR DESCRIPTION
# Description

Fixes bug where running a directed limited connected trace with `maximumSteps = 1` could return equipment 2 steps away. See https://app.clickup.com/t/6929263/EWB-2538 for more detailed explanation.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- None

Tasks mirroring this one:
- Same bug fix in Python SDK: https://github.com/zepben/evolve-sdk-python/pull/116

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have handled all new warnings generated by the compiler or IDE.
