### PR TITLE
Don't resolve EquipmentContainers when resolving references.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,8 @@
 
 ### Fixes
 
-* None.
+* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be 
+explicitly requested by the client.
 
 ### Notes
 

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -94,7 +94,8 @@ class NetworkConsumerClient(
         equipmentContainer: EquipmentContainer,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = getEquipmentForContainer(equipmentContainer.mRID, includeEnergizingContainers, includeEnergizedContainers)
+    ): GrpcResult<MultiObjectResult> =
+        getEquipmentForContainer(equipmentContainer.mRID, includeEnergizingContainers, includeEnergizedContainers)
 
     /**
      * Retrieve the [Equipment] for the [EquipmentContainer] represented by [mRID]
@@ -116,7 +117,8 @@ class NetworkConsumerClient(
         mRID: String,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = getEquipmentForContainers(sequenceOf(mRID), includeEnergizingContainers, includeEnergizedContainers)
+    ): GrpcResult<MultiObjectResult> =
+        getEquipmentForContainers(sequenceOf(mRID), includeEnergizingContainers, includeEnergizedContainers)
 
     /**
      * Retrieve the [Equipment] for all [EquipmentContainer]s represented by [mRIDs]
@@ -138,7 +140,8 @@ class NetworkConsumerClient(
         mRIDs: Iterable<String>,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = getEquipmentForContainers(mRIDs.asSequence(), includeEnergizingContainers, includeEnergizedContainers)
+    ): GrpcResult<MultiObjectResult> =
+        getEquipmentForContainers(mRIDs.asSequence(), includeEnergizingContainers, includeEnergizedContainers)
 
     /**
      * Retrieve the [Equipment] for all [EquipmentContainer]s represented by [mRIDs]
@@ -160,9 +163,8 @@ class NetworkConsumerClient(
         mRIDs: Sequence<String>,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = handleMultiObjectRPC {
-        processEquipmentForContainers(mRIDs, includeEnergizingContainers, includeEnergizedContainers)
-    }
+    ): GrpcResult<MultiObjectResult> =
+        handleMultiObjectRPC { processEquipmentForContainers(mRIDs, includeEnergizingContainers, includeEnergizedContainers) }
 
     /**
      * Retrieve the [Equipment] for [operationalRestriction].
@@ -262,25 +264,26 @@ class NetworkConsumerClient(
      *
      * @return A simplified version of the network hierarchy that can be used to make further in-depth requests.
      */
-    fun getNetworkHierarchy(): GrpcResult<NetworkHierarchy> = tryRpc {
-        if (networkHierarchy == null) {
-            val streamObserver = AwaitableStreamObserver<GetNetworkHierarchyResponse> { response ->
-                networkHierarchy = NetworkHierarchy(
-                    toMap(response.geographicalRegionsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
-                    toMap(response.subGeographicalRegionsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
-                    toMap(response.substationsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
-                    toMap(response.feedersList) { getOrAdd(it.mRID()) { addFromPb(it) } },
-                    toMap(response.circuitsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
-                    toMap(response.loopsList) { getOrAdd(it.mRID()) { addFromPb(it) } }
-                )
+    fun getNetworkHierarchy(): GrpcResult<NetworkHierarchy> =
+        tryRpc {
+            if (networkHierarchy == null) {
+                val streamObserver = AwaitableStreamObserver<GetNetworkHierarchyResponse> { response ->
+                    networkHierarchy = NetworkHierarchy(
+                        toMap(response.geographicalRegionsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
+                        toMap(response.subGeographicalRegionsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
+                        toMap(response.substationsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
+                        toMap(response.feedersList) { getOrAdd(it.mRID()) { addFromPb(it) } },
+                        toMap(response.circuitsList) { getOrAdd(it.mRID()) { addFromPb(it) } },
+                        toMap(response.loopsList) { getOrAdd(it.mRID()) { addFromPb(it) } }
+                    )
+                }
+
+                stub.getNetworkHierarchy(GetNetworkHierarchyRequest.newBuilder().build(), streamObserver)
+
+                streamObserver.await()
             }
-
-            stub.getNetworkHierarchy(GetNetworkHierarchyRequest.newBuilder().build(), streamObserver)
-
-            streamObserver.await()
+            networkHierarchy ?: throw IOException("No network hierarchy was received before GRPC channel was closed.")
         }
-        networkHierarchy ?: throw IOException("No network hierarchy was received before GRPC channel was closed.")
-    }
 
     /***
      * Retrieve the equipment container network for the specified [mRID] and store the results in the [service].
@@ -341,7 +344,8 @@ class NetworkConsumerClient(
         expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = getEquipmentContainers(mRIDs.asSequence(), expectedClass, includeEnergizingContainers, includeEnergizedContainers)
+    ): GrpcResult<MultiObjectResult> =
+        getEquipmentContainers(mRIDs.asSequence(), expectedClass, includeEnergizingContainers, includeEnergizedContainers)
 
     /***
      * Retrieve the equipment container networks for the specified [mRID]s and store the results in the [service].
@@ -366,13 +370,14 @@ class NetworkConsumerClient(
         expectedClass: Class<out EquipmentContainer> = EquipmentContainer::class.java,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
         includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
-    ): GrpcResult<MultiObjectResult> = getWithReferences(mRIDs, expectedClass) { it, mor ->
-        mor.objects.putAll(getEquipmentForContainers(it.map { eq -> eq.mRID }, includeEnergizingContainers, includeEnergizedContainers)
-            .onError { thrown, wasHandled -> return@getWithReferences GrpcResult.ofError(thrown, wasHandled) }
-            .value.objects
-        )
-        null
-    }
+    ): GrpcResult<MultiObjectResult> =
+        getWithReferences(mRIDs, expectedClass) { it, mor ->
+            mor.objects.putAll(getEquipmentForContainers(it.map { eq -> eq.mRID }, includeEnergizingContainers, includeEnergizedContainers)
+                .onError { thrown, wasHandled -> return@getWithReferences GrpcResult.ofError(thrown, wasHandled) }
+                .value.objects
+            )
+            null
+        }
 
     /**
      * Retrieve the [Equipment] for the [loop]
@@ -547,8 +552,8 @@ class NetworkConsumerClient(
         return extractResults.asSequence()
     }
 
-    private fun extractIdentifiedObject(io: NetworkIdentifiedObject): ExtractResult {
-        return when (io.identifiedObjectCase) {
+    private fun extractIdentifiedObject(io: NetworkIdentifiedObject): ExtractResult =
+        when (io.identifiedObjectCase) {
             BATTERYUNIT -> extractResult(io.batteryUnit.mRID()) { addFromPb(io.batteryUnit) }
             PHOTOVOLTAICUNIT -> extractResult(io.photoVoltaicUnit.mRID()) { addFromPb(io.photoVoltaicUnit) }
             POWERELECTRONICSWINDUNIT -> extractResult(io.powerElectronicsWindUnit.mRID()) { addFromPb(io.powerElectronicsWindUnit) }
@@ -621,11 +626,11 @@ class NetworkConsumerClient(
                 "Identified object type ${io.identifiedObjectCase} is not supported by the network service"
             )
         }
-    }
 
-    private fun <T, U : IdentifiedObject> toMap(objects: Iterable<T>, mapper: (T) -> U?): Map<String, U> = objects
-        .mapNotNull(mapper)
-        .associateBy { it.mRID }
+    private fun <T, U : IdentifiedObject> toMap(objects: Iterable<T>, mapper: (T) -> U?): Map<String, U> =
+        objects
+            .mapNotNull(mapper)
+            .associateBy { it.mRID }
 
     private fun handleMultiObjectRPC(processor: () -> Sequence<ExtractResult>): GrpcResult<MultiObjectResult> =
         tryRpc {
@@ -641,7 +646,8 @@ class NetworkConsumerClient(
         mRID: String,
         expectedClass: Class<out T>,
         getAdditional: (T, MultiObjectResult) -> GrpcResult<MultiObjectResult>?
-    ): GrpcResult<MultiObjectResult> = getWithReferences(sequenceOf(mRID), expectedClass) { it, mor -> getAdditional(it.elementAt(0), mor) }
+    ): GrpcResult<MultiObjectResult> =
+        getWithReferences(sequenceOf(mRID), expectedClass) { it, mor -> getAdditional(it.elementAt(0), mor) }
 
     private inline fun <reified T> getWithReferences(
         mRIDs: Sequence<String>,
@@ -677,12 +683,13 @@ class NetworkConsumerClient(
 
     internal fun resolveReferences(mor: MultiObjectResult): GrpcResult<MultiObjectResult>? {
         var res = mor
+        var subsequent = false
         do {
-            // Skip any reference trying to resolve from an EquipmentContainer - e.g a PowerTransformer trying to pull in its LvFeeder.
+            // Skip any reference trying to resolve from an EquipmentContainer on subsequent passes - e.g a PowerTransformer trying to pull in its LvFeeder.
             // EquipmentContainers should be retrieved explicitly or via a hierarchy call.
             val toResolve = res.objects.keys
                 .flatMap { service.getUnresolvedReferencesFrom(it) }
-                .filterNot { EquipmentContainer::class.java.isAssignableFrom(it.resolver.fromClass) }
+                .filterNot { subsequent && EquipmentContainer::class.java.isAssignableFrom(it.resolver.fromClass) }
                 .map { it.toMrid }
                 .distinct()
                 .toList()
@@ -691,6 +698,8 @@ class NetworkConsumerClient(
                 return GrpcResult.ofError(thrown, wasHandled)
             }.value
             mor.objects.putAll(res.objects)
+
+            subsequent = true
         } while (res.objects.isNotEmpty())
         return null
     }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -678,9 +678,11 @@ class NetworkConsumerClient(
     internal fun resolveReferences(mor: MultiObjectResult): GrpcResult<MultiObjectResult>? {
         var res = mor
         do {
+            // Skip any reference trying to resolve from an EquipmentContainer - e.g a PowerTransformer trying to pull in its LvFeeder.
+            // EquipmentContainers should be retrieved explicitly or via a hierarchy call.
             val toResolve = res.objects.keys
-                .asSequence()
                 .flatMap { service.getUnresolvedReferencesFrom(it) }
+                .filterNot { EquipmentContainer::class.java.isAssignableFrom(it.resolver.fromClass) }
                 .map { it.toMrid }
                 .distinct()
                 .toList()

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/TestDataCreators.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/TestDataCreators.kt
@@ -16,6 +16,7 @@ import com.zepben.evolve.cim.iec61968.metering.UsagePoint
 import com.zepben.evolve.cim.iec61968.operations.OperationalRestriction
 import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.*
+import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.customer.CustomerService
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.Tracing
@@ -194,6 +195,29 @@ fun createFeeder(networkService: NetworkService, mRID: String, name: String, sub
                 this.addEquipment(conductingEquipment)
             }
         }
+
+fun createLvFeeder(
+    networkService: NetworkService,
+    mRID: String,
+    name: String = "",
+    feeder: Feeder? = null,
+    headTerminal: Terminal? = null,
+    vararg equipmentMRIDs: String?
+): LvFeeder =
+    LvFeeder(mRID).apply {
+        this.name = name
+        normalHeadTerminal = headTerminal
+        feeder?.let { addNormalEnergizingFeeder(it) }
+
+        equipmentMRIDs.forEach {
+            networkService.get<ConductingEquipment>(it)?.also { ce ->
+                ce.addContainer(this)
+                addEquipment(ce)
+            }
+        }
+
+        networkService.add(this)
+    }
 
 fun createEnd(networkService: NetworkService, tx: PowerTransformer, ratedU: Int? = null, endNumber: Int = 0) =
     PowerTransformerEnd().also {

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/TestDataCreators.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/TestDataCreators.kt
@@ -16,7 +16,6 @@ import com.zepben.evolve.cim.iec61968.metering.UsagePoint
 import com.zepben.evolve.cim.iec61968.operations.OperationalRestriction
 import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.*
-import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.customer.CustomerService
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.Tracing
@@ -195,29 +194,6 @@ fun createFeeder(networkService: NetworkService, mRID: String, name: String, sub
                 this.addEquipment(conductingEquipment)
             }
         }
-
-fun createLvFeeder(
-    networkService: NetworkService,
-    mRID: String,
-    name: String = "",
-    feeder: Feeder? = null,
-    headTerminal: Terminal? = null,
-    vararg equipmentMRIDs: String?
-): LvFeeder =
-    LvFeeder(mRID).apply {
-        this.name = name
-        normalHeadTerminal = headTerminal
-        feeder?.let { addNormalEnergizingFeeder(it) }
-
-        equipmentMRIDs.forEach {
-            networkService.get<ConductingEquipment>(it)?.also { ce ->
-                ce.addContainer(this)
-                addEquipment(ce)
-            }
-        }
-
-        networkService.add(this)
-    }
 
 fun createEnd(networkService: NetworkService, tx: PowerTransformer, ratedU: Int? = null, endNumber: Int = 0) =
     PowerTransformerEnd().also {

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -7,9 +7,6 @@
  */
 package com.zepben.evolve.streaming.get
 
-import com.zepben.evolve.cim.iec61968.assetinfo.CableInfo
-import com.zepben.evolve.cim.iec61968.assetinfo.OverheadWireInfo
-import com.zepben.evolve.cim.iec61968.common.Location
 import com.zepben.evolve.cim.iec61968.operations.OperationalRestriction
 import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.*
@@ -659,7 +656,7 @@ internal class NetworkConsumerClientTest {
         val expectedService = LvFeedersWithOpenPoint.create()
         configureFeederResponses(expectedService)
 
-        val mRID = "lvf001"
+        val mRID = "lvf5"
         val result = consumerClient.getEquipmentContainer<LvFeeder>(mRID).throwOnError()
 
         verify(consumerService.onGetNetworkHierarchy, times(1)).invoke(any(), any())
@@ -668,10 +665,29 @@ internal class NetworkConsumerClientTest {
         verifyNoMoreInteractions(consumerService.onGetNetworkHierarchy)
 
         assertThat(result.wasSuccessful, equalTo(true))
-        assertThat(result.value.objects.containsKey(mRID), equalTo(true))
-        assertThat(result.value.objects.size, equalTo(18))
-        assertThat(consumerClient.service.get<PowerTransformer>("tx2"), nullValue())
-        assertThat(consumerClient.service.get<PowerTransformer>("tx1"), equalTo(result.value.objects["tx1"]))
+        assertThat(
+            result.value.objects.keys,
+            containsInAnyOrder(
+                "lvf5",
+                "tx0",
+                "c1",
+                "b2",
+                "tx0-t2",
+                "tx0-e1",
+                "tx0-e2",
+                "tx0-t1",
+                "c1-t1",
+                "c1-t2",
+                "b2-t1",
+                "b2-t2",
+                "lvf6",
+                "generated_cn_0",
+                "generated_cn_1",
+                "generated_cn_2",
+            )
+        )
+        assertThat(consumerClient.service.get<PowerTransformer>("tx4"), nullValue())
+        assertThat(consumerClient.service.get<PowerTransformer>("tx0"), equalTo(result.value.objects["tx0"]))
     }
 
     private fun createResponse(

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
@@ -13,8 +13,8 @@ import com.zepben.evolve.testing.TestNetworkBuilder
 
 object LvFeedersWithOpenPoint {
 
-    //    lv1:[     c1  {  ]  c2     }:lv2
-    //    lv1:[tx1------{sw]------tx2}:lv2
+    //    lvf5:[     c1  {  ]  c3     }:lvf6
+    //    lvf5:[tx0------{b2]------tx4}:lvf6
     fun create(): NetworkService =
         TestNetworkBuilder()
             .fromPowerTransformer() // tx0

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.streaming.get.testdata
+
+import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.testdata.*
+import com.zepben.evolve.services.network.tracing.Tracing
+
+object LvFeedersWithOpenPoint {
+
+    //    lv1:[     c1  {  ]  c2     }:lv2
+    //    lv1:[tx1------{sw]------tx2}:lv2
+    fun create(): NetworkService {
+        val networkService = NetworkService()
+
+        val sw = createSwitchForConnecting(networkService, "sw", 2, nominalPhases = PhaseCode.AB).apply {
+            setOpen(true)
+            setNormallyOpen(true)
+        }
+
+        val tx1 = createPowerTransformerForConnecting(networkService, "tx1", 2, 0, 0, PhaseCode.AB)
+        val tx2 = createPowerTransformerForConnecting(networkService, "tx2", 2, 0, 0, PhaseCode.AB)
+
+        val c1 = createAcLineSegmentForConnecting(networkService, "c1", PhaseCode.AB)
+        val c2 = createAcLineSegmentForConnecting(networkService, "c2", PhaseCode.AB)
+
+        createEnd(networkService, tx1, 22000, 1)
+        createEnd(networkService, tx1, 415, 2)
+        createEnd(networkService, tx2, 22000, 1)
+        createEnd(networkService, tx2, 415, 2)
+
+        createLvFeeder(networkService, "lvf001", "lvf001", headTerminal = tx1.getTerminal(2))
+        createLvFeeder(networkService, "lvf002", "lvf002", headTerminal = tx2.getTerminal(2))
+
+        networkService.connect(c1.getTerminal(1)!!, tx1.getTerminal(2)!!)
+        networkService.connect(c2.getTerminal(1)!!, tx2.getTerminal(2)!!)
+        networkService.connect(c1.getTerminal(2)!!, sw.getTerminal(2)!!)
+        networkService.connect(c2.getTerminal(2)!!, sw.getTerminal(1)!!)
+
+        Tracing.setPhases().run(networkService)
+        Tracing.assignEquipmentToLvFeeders().run(networkService)
+
+        return networkService
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testdata/LvFeedersWithOpenPoint.kt
@@ -8,46 +8,22 @@
 
 package com.zepben.evolve.streaming.get.testdata
 
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.services.network.NetworkService
-import com.zepben.evolve.services.network.testdata.*
-import com.zepben.evolve.services.network.tracing.Tracing
+import com.zepben.evolve.testing.TestNetworkBuilder
 
 object LvFeedersWithOpenPoint {
 
     //    lv1:[     c1  {  ]  c2     }:lv2
     //    lv1:[tx1------{sw]------tx2}:lv2
-    fun create(): NetworkService {
-        val networkService = NetworkService()
-
-        val sw = createSwitchForConnecting(networkService, "sw", 2, nominalPhases = PhaseCode.AB).apply {
-            setOpen(true)
-            setNormallyOpen(true)
-        }
-
-        val tx1 = createPowerTransformerForConnecting(networkService, "tx1", 2, 0, 0, PhaseCode.AB)
-        val tx2 = createPowerTransformerForConnecting(networkService, "tx2", 2, 0, 0, PhaseCode.AB)
-
-        val c1 = createAcLineSegmentForConnecting(networkService, "c1", PhaseCode.AB)
-        val c2 = createAcLineSegmentForConnecting(networkService, "c2", PhaseCode.AB)
-
-        createEnd(networkService, tx1, 22000, 1)
-        createEnd(networkService, tx1, 415, 2)
-        createEnd(networkService, tx2, 22000, 1)
-        createEnd(networkService, tx2, 415, 2)
-
-        createLvFeeder(networkService, "lvf001", "lvf001", headTerminal = tx1.getTerminal(2))
-        createLvFeeder(networkService, "lvf002", "lvf002", headTerminal = tx2.getTerminal(2))
-
-        networkService.connect(c1.getTerminal(1)!!, tx1.getTerminal(2)!!)
-        networkService.connect(c2.getTerminal(1)!!, tx2.getTerminal(2)!!)
-        networkService.connect(c1.getTerminal(2)!!, sw.getTerminal(2)!!)
-        networkService.connect(c2.getTerminal(2)!!, sw.getTerminal(1)!!)
-
-        Tracing.setPhases().run(networkService)
-        Tracing.assignEquipmentToLvFeeders().run(networkService)
-
-        return networkService
-    }
+    fun create(): NetworkService =
+        TestNetworkBuilder()
+            .fromPowerTransformer() // tx0
+            .toAcls() // c1
+            .toBreaker(isNormallyOpen = true) // b2
+            .toAcls() // c3
+            .toPowerTransformer() // tx4
+            .addLvFeeder("tx0", 2) // lvf5
+            .addLvFeeder("tx4", 1) // lvf6
+            .build()
 
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcClientTest.kt
@@ -83,7 +83,7 @@ internal class GrpcClientTest {
             every { it.awaitTermination(any(), any()) } returns true
         }
 
-        val client1 = object : GrpcClient(executor){}
+        val client1 = object : GrpcClient(executor) {}
 
         client1.close()
 
@@ -100,7 +100,7 @@ internal class GrpcClientTest {
             every { it.shutdownNow() } returns emptyList()
         }
 
-        val client1 = object : GrpcClient(executor){}
+        val client1 = object : GrpcClient(executor) {}
 
         client1.close()
 
@@ -112,7 +112,7 @@ internal class GrpcClientTest {
 
     @Test
     internal fun `supports null executor`() {
-        val client1 = object : GrpcClient(null){}
+        val client1 = object : GrpcClient(null) {}
         client1.close()
     }
 


### PR DESCRIPTION
# Description

This stops open points between LvFeeders pulling in other LvFeeders and their equipment

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
