### PR TITLE
EWB-3608: Performance enhancement for `ConnectedEquipmentTrace`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,26 @@
 # Zepben EWB SDK changelog
+
 ## [0.16.0] - UNRELEASED
+
 ### Breaking Changes
+
 * None.
 
 ### New Features
+
 * None.
 
 ### Enhancements
-* None.
+
+* Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.
 
 ### Fixes
+
 * None.
 
 ### Notes
-* None.
 
+* None.
 
 ## [0.15.0]
 
@@ -38,8 +44,8 @@
 
 ### Fixes
 
-* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be 
-explicitly requested by the client.
+* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be
+  explicitly requested by the client.
 
 ### Notes
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/ConnectedEquipmentTrace.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/ConnectedEquipmentTrace.kt
@@ -102,7 +102,7 @@ object ConnectedEquipmentTrace {
 
     private fun queueNext(openTest: OpenTest): BasicTraversal.QueueNext<ConductingEquipmentStep> =
         BasicTraversal.QueueNext { (conductingEquipment, step), traversal ->
-            if ((step == 0) || !openTest.isOpen(conductingEquipment, null)) {
+            if ((step == 0) || ((conductingEquipment.numTerminals() > 1) && !openTest.isOpen(conductingEquipment, null))) {
                 val nextStep = step + 1
                 conductingEquipment.terminals
                     .asSequence()


### PR DESCRIPTION
# Description

Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
