### PR TITLE
PROJ-3406: Asking for the traced phases as a phase code when there are no nominal phases no longer throws.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@
 
 ### Fixes
 
-* None.
+* Asking for the traced phases as a phase code when there are no nominal phases no longer throws.
 
 ### Notes
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseStatus.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseStatus.kt
@@ -39,6 +39,9 @@ abstract class PhaseStatus(private val terminal: Terminal) {
      * @return The [PhaseCode] if the combination of phases makes sense, otherwise null.
      */
     fun asPhaseCode(): PhaseCode? {
+        if (terminal.phases == PhaseCode.NONE)
+            return PhaseCode.NONE
+
         val tracedPhases = terminal.phases.singlePhases.map { get(it) }
         val phases = tracedPhases.toSet()
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelectorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelectorTest.kt
@@ -144,6 +144,24 @@ class PhaseSelectorTest {
     }
 
     @Test
+    fun testAsPhaseCodeNone() {
+        val terminal = Terminal().apply { phases = PhaseCode.NONE }
+        val normalPhases = terminal.normalPhases
+        val currentPhases = terminal.currentPhases
+
+        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
+        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
+
+        PhaseCode.ABCN.singlePhases.forEach {
+            normalPhases[it] = it
+            currentPhases[it] = it
+        }
+
+        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
+        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
+    }
+
+    @Test
     fun asPhaseCodeHandlesChangingTerminalPhases() {
         val terminal = Terminal().apply { phases = PhaseCode.BC }
         val normalPhases = terminal.normalPhases


### PR DESCRIPTION
# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
