### PR TITLE
PROJ-3555: Bump version of evolve-grpc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.25.0-SNAPSHOT2</version>
+            <version>0.25.0-SNAPSHOT3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Description

Bumps version of evolve-grpc to support the added config fields

# Associated tasks:

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-grpc/pull/72

Tasks this is blocking:
- https://github.com/zepben/network-verifier-lib/pull/25
- Update opendss-exporter-jvm

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary. (Only a non-breaking protobuf schema update)

These you can remove from the list if they are not applicable for this PR.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so. (Not breaking)
