### PR TITLE
EWB-3787: LV2 support and trace enhancements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
     * You can now set the ID's without having to create a customer 'other' creator.
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
+    * Added inbuilt support for `PowerElectronicsConnection` and `EnergyConsumer`
 * Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 * `TraversalQueue` now has `addAll` methods taking either a collection or varargs, which by default will just call `add` for each item, but can be overridden if
   there is an `addAll` available on the underlying queue implementation.

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 ### Enhancements
 
 * Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.
+* Added support for LV2 below SWER transformers.
 * Improved logging when saving a database.
 
 ### Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,8 @@
 ### Fixes
 
 * Asking for the traced phases as a phase code when there are no nominal phases no longer throws.
+* Feeder directions are now stopped at substation transformers in the same way as assigning equipment incase the feeder has no breaker, or the start point is
+  not inline.
 
 ### Notes
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,15 @@
 
 ### Breaking Changes
 
-* None.
+* Deprecated old style accessors in favour of Kotlin accessors for `SinglePhaseKind`. To use the new function make the folloiwng modification to your code:
+    * Kotlin:
+        * `spk.value()` -> `spk.value`
+        * `spk.maskIndex()` -> `spk.maskIndex`
+        * `spk.bitMask()` -> `spk.bitMask`
+    * Java:
+        * `spk.value()` -> `spk.getValue()`
+        * `spk.maskIndex()` -> `spk.getMaskIndex()`
+        * `spk.bitMask()` -> `spk.getBitMask()`
 
 ### New Features
 
@@ -37,6 +45,7 @@
     * You can now set the ID's without having to create a customer 'other' creator.
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
+* Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 ### Enhancements
 
 * Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.
+* Improved logging when saving a database.
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,10 @@
 * Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.
 * Added support for LV2 below SWER transformers.
 * Improved logging when saving a database.
+* The `TestNetworkBuilder` has been enhanced with the following features:
+    * You can now set the ID's without having to create a customer 'other' creator.
+    * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
+      of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
         * `spk.value()` -> `spk.getValue()`
         * `spk.maskIndex()` -> `spk.getMaskIndex()`
         * `spk.bitMask()` -> `spk.getBitMask()`
+* `SetDirection.run(NetworkService)` will no longer set directions for feeders with a head terminal on an open switch. It is expected these feeders are either
+  placeholder feeders with no meaningful equipment, or are energised from another feeder which will set the directions from the other end.
 
 ### New Features
 

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,11 @@
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
 * Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
+* `TraversalQueue` now has `addAll` methods taking either a collection or varargs, which by default will just call `add` for each item, but can be overridden if
+  there is an `addAll` available on the underlying queue implementation.
+* `Traversal` has two new helper methods:
+    * `ifNotStopping`: Adds a step action that is only called if the traversal is not stopping on the item.
+    * `ifStopping`: Adds a step action that is only called if the traversal is stopping on the item.
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
     * Added inbuilt support for `PowerElectronicsConnection` and `EnergyConsumer`
+    * The `to*` and `connect` functions can specify the connectivity node mRID to use. This will only be used if the terminals are not already connected.
 * Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 * `TraversalQueue` now has `addAll` methods taking either a collection or varargs, which by default will just call `add` for each item, but can be overridden if
   there is an `addAll` available on the underlying queue implementation.

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/PhaseCode.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/PhaseCode.kt
@@ -99,6 +99,11 @@ enum class PhaseCode(vararg singlePhases: SinglePhaseKind) {
     }
 
     operator fun contains(phase: SinglePhaseKind): Boolean = singlePhases.contains(phase)
+    operator fun plus(phase: SinglePhaseKind): PhaseCode = fromSinglePhases(singlePhases + phase)
+    operator fun plus(phaseCode: PhaseCode): PhaseCode = fromSinglePhases(singlePhases + phaseCode.singlePhases)
+    operator fun minus(phase: SinglePhaseKind): PhaseCode = fromSinglePhases(singlePhases - phase)
+    operator fun minus(phaseCode: PhaseCode): PhaseCode = fromSinglePhases(singlePhases - phaseCode.singlePhases.toSet())
+
     fun <R> map(transform: (SinglePhaseKind) -> R): List<R> = singlePhases.map(transform)
     fun any(predicate: (SinglePhaseKind) -> Boolean): Boolean = singlePhases.any(predicate)
     fun all(predicate: (SinglePhaseKind) -> Boolean): Boolean = singlePhases.all(predicate)

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerEnd.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/PowerTransformerEnd.kt
@@ -69,8 +69,10 @@ class PowerTransformerEnd @JvmOverloads constructor(mRID: String = "") : Transfo
 
     var ratedS: Int?
         get() = _sRatings?.firstOrNull()?.ratedS
-        @Deprecated("Use addRating() instead, as this will clear all ratings and is intended for backwards compatibility only",
-            ReplaceWith("addRating(this)"))
+        @Deprecated(
+            "Use addRating() instead, as this will clear all ratings and is intended for backwards compatibility only",
+            ReplaceWith("addRating(value, TransformerCoolingType.UNKNOWN_COOLING_TYPE)")
+        )
         set(value) {
             if (value != null) {
                 clearRatings()

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/SinglePhaseKind.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/SinglePhaseKind.kt
@@ -7,6 +7,9 @@
  */
 package com.zepben.evolve.cim.iec61970.base.wires
 
+import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind.*
+
 /**
  * Enumeration of single phase identifiers. Allows designation of single phases for both transmission and distribution equipment, circuits and loads.
  *
@@ -21,7 +24,7 @@ package com.zepben.evolve.cim.iec61970.base.wires
  * @property s2 Secondary phase 2.
  * @property INVALID Invalid phase. Caused by trying to energise with multiple phases simultaneously.
  */
-enum class SinglePhaseKind(private val value: Int, private val maskIndex: Int) {
+enum class SinglePhaseKind(val value: Int, val maskIndex: Int) {
 
     NONE(0, -1),
     A(1, 0),
@@ -43,17 +46,26 @@ enum class SinglePhaseKind(private val value: Int, private val maskIndex: Int) {
         }
     }
 
-    private val bitMask = if (maskIndex >= 0) 1 shl maskIndex else 0
+    val bitMask = if (maskIndex >= 0) 1 shl maskIndex else 0
 
+    operator fun plus(phase: SinglePhaseKind): PhaseCode = PhaseCode.fromSinglePhases(setOf(this) + phase)
+    operator fun plus(phaseCode: PhaseCode): PhaseCode = PhaseCode.fromSinglePhases(setOf(this) + phaseCode.singlePhases)
+    operator fun minus(phase: SinglePhaseKind): PhaseCode = PhaseCode.fromSinglePhases(setOf(this) - phase)
+    operator fun minus(phaseCode: PhaseCode): PhaseCode = PhaseCode.fromSinglePhases(setOf(this) - phaseCode.singlePhases.toSet())
+
+    @Deprecated("Use `value` (or `getValue()` in java) instead.", ReplaceWith("value"))
     fun value(): Int {
         return value
     }
 
+    @Deprecated("Use `maskIndex` (or `getMaskIndex()` in java) instead.", ReplaceWith("maskIndex"))
     fun maskIndex(): Int {
         return maskIndex
     }
 
+    @Deprecated("Use `bitMask` (or `getBitMask()` in java) instead.", ReplaceWith("bitMask"))
     fun bitMask(): Int {
         return bitMask
     }
+
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TransformerPhasePaths.kt
@@ -86,18 +86,24 @@ object TransformerPhasePaths {
             PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.B, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.AB to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B)),
             PhaseCode.XY to listOf(path(SPK.A, SPK.X), path(SPK.B, SPK.Y)),
+            PhaseCode.A to listOf(path(SPK.A, SPK.A)),
+            PhaseCode.X to listOf(path(SPK.A, SPK.X)),
         ),
         PhaseCode.BCN to mapOf(
             PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
             PhaseCode.XYN to listOf(path(SPK.B, SPK.X), path(SPK.C, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.BC to listOf(path(SPK.B, SPK.B), path(SPK.C, SPK.C)),
             PhaseCode.XY to listOf(path(SPK.B, SPK.X), path(SPK.C, SPK.Y)),
+            PhaseCode.B to listOf(path(SPK.B, SPK.B)),
+            PhaseCode.X to listOf(path(SPK.B, SPK.X)),
         ),
         PhaseCode.ACN to mapOf(
             PhaseCode.ACN to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C), path(SPK.N, SPK.N)),
             PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.C, SPK.Y), path(SPK.N, SPK.N)),
             PhaseCode.AC to listOf(path(SPK.A, SPK.A), path(SPK.C, SPK.C)),
             PhaseCode.XY to listOf(path(SPK.A, SPK.X), path(SPK.C, SPK.Y)),
+            PhaseCode.C to listOf(path(SPK.C, SPK.C)),
+            PhaseCode.X to listOf(path(SPK.C, SPK.X)),
         ),
         PhaseCode.XYN to mapOf(
             PhaseCode.ABN to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.B), path(SPK.N, SPK.N)),
@@ -108,6 +114,10 @@ object TransformerPhasePaths {
             PhaseCode.BC to listOf(path(SPK.X, SPK.B), path(SPK.Y, SPK.C)),
             PhaseCode.AC to listOf(path(SPK.X, SPK.A), path(SPK.Y, SPK.C)),
             PhaseCode.XY to listOf(path(SPK.X, SPK.X), path(SPK.Y, SPK.Y)),
+            PhaseCode.A to listOf(path(SPK.X, SPK.A)),
+            PhaseCode.B to listOf(path(SPK.X, SPK.B)),
+            PhaseCode.C to listOf(path(SPK.X, SPK.C)),
+            PhaseCode.X to listOf(path(SPK.X, SPK.X)),
         ),
         PhaseCode.AB to mapOf(
             PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.B, SPK.B), addNeutral),
@@ -164,6 +174,8 @@ object TransformerPhasePaths {
             PhaseCode.XY to listOf(path(SPK.A, SPK.X), path(SPK.NONE, SPK.Y)),
             PhaseCode.A to listOf(path(SPK.A, SPK.A)),
             PhaseCode.X to listOf(path(SPK.A, SPK.X)),
+            PhaseCode.ABN to listOf(path(SPK.A, SPK.A), path(SPK.NONE, SPK.B), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.A, SPK.X), path(SPK.NONE, SPK.Y), addNeutral),
         ),
         PhaseCode.B to mapOf(
             PhaseCode.BN to listOf(path(SPK.B, SPK.B), addNeutral),
@@ -172,6 +184,8 @@ object TransformerPhasePaths {
             PhaseCode.XY to listOf(path(SPK.B, SPK.X), path(SPK.NONE, SPK.Y)),
             PhaseCode.B to listOf(path(SPK.B, SPK.B)),
             PhaseCode.X to listOf(path(SPK.B, SPK.X)),
+            PhaseCode.BCN to listOf(path(SPK.B, SPK.B), path(SPK.NONE, SPK.C), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.B, SPK.X), path(SPK.NONE, SPK.Y), addNeutral),
         ),
         PhaseCode.C to mapOf(
             PhaseCode.CN to listOf(path(SPK.C, SPK.C), addNeutral),
@@ -180,6 +194,8 @@ object TransformerPhasePaths {
             PhaseCode.XY to listOf(path(SPK.C, SPK.X), path(SPK.NONE, SPK.Y)),
             PhaseCode.C to listOf(path(SPK.C, SPK.C)),
             PhaseCode.X to listOf(path(SPK.C, SPK.X)),
+            PhaseCode.ACN to listOf(path(SPK.C, SPK.C), path(SPK.NONE, SPK.A), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.C, SPK.X), path(SPK.NONE, SPK.Y), addNeutral),
         ),
         PhaseCode.X to mapOf(
             PhaseCode.AN to listOf(path(SPK.X, SPK.A), addNeutral),
@@ -194,6 +210,10 @@ object TransformerPhasePaths {
             PhaseCode.B to listOf(path(SPK.X, SPK.B)),
             PhaseCode.C to listOf(path(SPK.X, SPK.C)),
             PhaseCode.X to listOf(path(SPK.X, SPK.X)),
+            PhaseCode.ABN to listOf(path(SPK.X, SPK.A), path(SPK.NONE, SPK.B), addNeutral),
+            PhaseCode.BCN to listOf(path(SPK.X, SPK.B), path(SPK.NONE, SPK.C), addNeutral),
+            PhaseCode.ACN to listOf(path(SPK.X, SPK.C), path(SPK.NONE, SPK.A), addNeutral),
+            PhaseCode.XYN to listOf(path(SPK.X, SPK.X), path(SPK.NONE, SPK.Y), addNeutral),
         ),
     )
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.services.network.tracing.feeder
 
 import com.zepben.evolve.cim.iec61970.base.core.Feeder
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.OpenTest
 import com.zepben.evolve.services.network.tracing.traversals.BasicTracker
@@ -102,6 +103,9 @@ class SetDirection {
                 .any { it.normalHeadTerminal == terminal }
         } ?: false
 
+    private fun reachedSubstationTransformer(terminal: Terminal): Boolean =
+        terminal.conductingEquipment.let { ce -> (ce is PowerTransformer) && ce.substations.isNotEmpty() }
+
     private fun flowUpstreamAndQueueNextStraight(
         traversal: BranchRecursiveTraversal<Terminal>,
         terminal: Terminal,
@@ -141,7 +145,7 @@ class SetDirection {
         if (!direction.add(FeederDirection.UPSTREAM))
             return
 
-        if (isFeederHeadTerminal(terminal))
+        if (isFeederHeadTerminal(terminal) || reachedSubstationTransformer(terminal))
             return
 
         val ce = terminal.conductingEquipment ?: return

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
@@ -8,9 +8,11 @@
 
 package com.zepben.evolve.services.network.tracing.feeder
 
+import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.evolve.cim.iec61970.base.core.Feeder
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
+import com.zepben.evolve.cim.iec61970.base.wires.Switch
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.OpenTest
 import com.zepben.evolve.services.network.tracing.traversals.BasicTracker
@@ -55,7 +57,7 @@ class SetDirection {
      * @param network The network in which to apply feeder directions.
      */
     fun run(network: NetworkService) {
-        run(network.sequenceOf<Feeder>().mapNotNull { it.normalHeadTerminal }.toList())
+        run(network.sequenceOf<Feeder>().mapNotNull { it.normalHeadTerminal }.filter { !it.conductingEquipment.isNormallyOpenSwitch() }.toList())
     }
 
     /**
@@ -157,6 +159,9 @@ class SetDirection {
             .filter { it != terminal }
             .forEach { queue(it) }
     }
+
+    private fun ConductingEquipment?.isNormallyOpenSwitch(): Boolean =
+        (this is Switch) && isNormallyOpen()
 
     private fun BranchRecursiveTraversal<Terminal>.startNewBranch(terminal: Terminal) {
         branchQueue.add(branchSupplier().setStart(terminal))

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/BasicQueue.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/BasicQueue.kt
@@ -31,6 +31,10 @@ open class BasicQueue<T> protected constructor(
         return queue.add(item)
     }
 
+    override fun addAll(items: Collection<T>): Boolean {
+        return queue.addAll(items)
+    }
+
     override fun peek(): T? {
         return queue.peek()
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/Traversal.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/Traversal.kt
@@ -112,8 +112,30 @@ abstract class Traversal<T> {
      * @param action Action to be called on each item in the traversal, without passing if the trace will stop on this step.
      * @return this traversal instance.
      */
-    fun addStepAction(action: (T) -> Unit): Traversal<T> {
+    fun addStepAction(action: (item: T) -> Unit): Traversal<T> {
         stepActions.add { it, _ -> action(it) }
+        return this
+    }
+
+    /**
+     * Add a callback which is called for every item in the traversal that does not match a stop condition (including the starting item).
+     *
+     * @param action Action to be called on each item in the traversal that is not being stopped on.
+     * @return this traversal instance.
+     */
+    fun ifNotStopping(action: (item: T) -> Unit): Traversal<T> {
+        stepActions.add { it, isStopping -> if (!isStopping) action(it) }
+        return this
+    }
+
+    /**
+     * Add a callback which is called for every item in the traversal that matches a stop condition (including the starting item).
+     *
+     * @param action Action to be called on each item in the traversal that is being stopped on.
+     * @return this traversal instance.
+     */
+    fun ifStopping(action: (item: T) -> Unit): Traversal<T> {
+        stepActions.add { it, isStopping -> if (isStopping) action(it) }
         return this
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/TraversalQueue.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversals/TraversalQueue.kt
@@ -37,6 +37,24 @@ interface TraversalQueue<T> {
     fun add(item: T): Boolean
 
     /**
+     * Adds the items to the queue.
+     *
+     * @param items A collection of items to add to the queue.
+     * @return true if the queue was changed as the result of the operation.
+     */
+    fun addAll(items: Collection<T>): Boolean =
+        items.fold(false) { result, item -> add(item) || result }
+
+    /**
+     * Adds the items to the queue.
+     *
+     * @param items The items to be added to the queue.
+     * @return true if the queue was changed as the result of the operation.
+     */
+    fun addAll(vararg items: T): Boolean =
+        addAll(items.asList())
+
+    /**
      * Look at the item at the front of the queue without removing it.  Most implementations of this interface will return
      * null is this is called when the queue is empty, however it is not enforced.
      */

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -44,7 +44,11 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun fromSource(phases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
+    fun fromSource(
+        phases: PhaseCode = PhaseCode.ABC,
+        mRID: String? = null,
+        action: EnergySource.() -> Unit = {}
+    ): TestNetworkBuilder {
         current = network.createExternalSource(mRID, phases).also(action)
         return this
     }
@@ -54,14 +58,21 @@ open class TestNetworkBuilder {
      *
      * @param phases The [PhaseCode] for the new [EnergySource], used as both the nominal and energising phases. Must be a subset of [PhaseCode.ABCN].
      * @param mRID Optional mRID for the new [EnergySource].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [EnergySource] to the previous item. Will only be used if the
+     * previous item is not already connected.
      * @param action An action that accepts the new [EnergySource] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun toSource(phases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
+    fun toSource(
+        phases: PhaseCode = PhaseCode.ABC,
+        mRID: String? = null,
+        connectivityNodeMrid: String? = null,
+        action: EnergySource.() -> Unit = {}
+    ): TestNetworkBuilder {
         current = network.createExternalSource(mRID, phases).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -77,7 +88,11 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun fromAcls(nominalPhases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
+    fun fromAcls(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        mRID: String? = null,
+        action: AcLineSegment.() -> Unit = {}
+    ): TestNetworkBuilder {
         current = network.createAcls(mRID, nominalPhases).also(action)
         return this
     }
@@ -87,14 +102,21 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for the new [AcLineSegment].
      * @param mRID Optional mRID for the new [AcLineSegment].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [AcLineSegment] to the previous item. Will only be used if the
+     * previous item is not already connected.
      * @param action An action that accepts the new [AcLineSegment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun toAcls(nominalPhases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
+    fun toAcls(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        mRID: String? = null,
+        connectivityNodeMrid: String? = null,
+        action: AcLineSegment.() -> Unit = {}
+    ): TestNetworkBuilder {
         current = network.createAcls(mRID, nominalPhases).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -130,6 +152,8 @@ open class TestNetworkBuilder {
      * @param isNormallyOpen The normal state of the switch. Defaults to false.
      * @param isOpen The current state of the switch. Defaults to [isNormallyOpen].
      * @param mRID Optional mRID for the new [Breaker].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [Breaker] to the previous item. Will only be used if the previous
+     * item is not already connected.
      * @param action An action that accepts the new [Breaker] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -140,10 +164,11 @@ open class TestNetworkBuilder {
         isNormallyOpen: Boolean = false,
         isOpen: Boolean? = null,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: Breaker.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createBreaker(mRID, nominalPhases, isNormallyOpen = isNormallyOpen, isOpen = isOpen ?: isNormallyOpen).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -176,6 +201,8 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [Junction].
      * @param numTerminals The number of terminals to create on the new [Junction]. Defaults to 2.
      * @param mRID Optional mRID for the new [Junction].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [Junction] to the previous item. Will only be used if the previous
+     * item is not already connected.
      * @param action An action that accepts the new [Junction] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -185,10 +212,11 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int? = null,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: Junction.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createJunction(mRID, nominalPhases, numTerminals).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -201,6 +229,8 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [PowerElectronicsConnection].
      * @param numTerminals The number of terminals to create on the new [PowerElectronicsConnection]. Defaults to 2.
      * @param mRID Optional mRID for the new [PowerElectronicsConnection].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [PowerElectronicsConnection] to the previous item. Will only be
+     * used if the previous item is not already connected.
      * @param action An action that accepts the new [PowerElectronicsConnection] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -210,10 +240,11 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int = 2,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: PowerElectronicsConnection.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createPowerElectronicsConnection(mRID, nominalPhases, numTerminals).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -251,6 +282,8 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for each end of the new [PowerTransformer]. Defaults to two [PhaseCode.ABC] ends.
      * @param endActions Actions that accepts the new [PowerTransformerEnd] to allow for additional initialisation.
      * @param mRID Optional mRID for the new [PowerTransformer].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [PowerTransformer] to the previous item. Will only be used if the
+     * previous item is not already connected.
      * @param action An action that accepts the new [PowerTransformer] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -260,10 +293,11 @@ open class TestNetworkBuilder {
         nominalPhases: List<PhaseCode> = listOf(PhaseCode.ABC, PhaseCode.ABC),
         endActions: List<PowerTransformerEnd.() -> Unit>? = null,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: PowerTransformer.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createPowerTransformer(mRID, nominalPhases).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             endActions?.forEachIndexed { index, endAction ->
                 endAction(it.ends[index])
             }
@@ -278,6 +312,8 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for the new [EnergyConsumer].
      * @param mRID Optional mRID for the new [EnergyConsumer].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [EnergyConsumer] to the previous item. Will only be used if the
+     * previous item is not already connected.
      * @param action An action that accepts the new [EnergyConsumer] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -286,10 +322,11 @@ open class TestNetworkBuilder {
     fun toEnergyConsumer(
         nominalPhases: PhaseCode = PhaseCode.ABC,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: EnergyConsumer.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createEnergyConsumer(mRID, nominalPhases).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -344,6 +381,8 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
      * @param mRID Optional mRID for the new [ConductingEquipment].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [ConductingEquipment] to the previous item. Will only be used if
+     * the previous item is not already connected.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -354,10 +393,11 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int? = null,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         action: ConductingEquipment.() -> Unit = {}
     ): TestNetworkBuilder {
         current = network.createOther(mRID, creator, nominalPhases, numTerminals).also {
-            connect(current!!, it)
+            connect(current!!, it, connectivityNodeMrid)
             action(it)
         }
         return this
@@ -370,6 +410,8 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
      * @param mRID Optional mRID for the new [ConductingEquipment].
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [ConductingEquipment] to the previous item. Will only be used if
+     * the previous item is not already connected.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -378,9 +420,10 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int? = null,
         mRID: String? = null,
+        connectivityNodeMrid: String? = null,
         noinline action: ConductingEquipment.() -> Unit = {}
     ): TestNetworkBuilder =
-        toOther({ T::class.primaryConstructor!!.call(it) }, nominalPhases, numTerminals, mRID, action)
+        toOther({ T::class.primaryConstructor!!.call(it) }, nominalPhases, numTerminals, mRID, connectivityNodeMrid, action)
 
     /**
      * Move the current network pointer to the specified [from] allowing branching of the network. This has the effect of changing the current network pointer.
@@ -403,11 +446,19 @@ open class TestNetworkBuilder {
      * @param to The mRID of the second [ConductingEquipment] to be connected.
      * @param fromTerminal The sequence number of the terminal on [from] which will be connected.
      * @param toTerminal The sequence number of the terminal on [to] which will be connected.
+     * @param connectivityNodeMrid Optional id of the connectivity node used to connect the terminals. Will only be used if both terminals are not already
+     * connected.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
-    fun connect(from: String, to: String, fromTerminal: Int, toTerminal: Int): TestNetworkBuilder {
-        connect(network[from]!!, network[to]!!, fromTerminal, toTerminal)
+    fun connect(
+        from: String,
+        to: String,
+        fromTerminal: Int,
+        toTerminal: Int,
+        connectivityNodeMrid: String? = null
+    ): TestNetworkBuilder {
+        connect(network[from]!!, network[to]!!, connectivityNodeMrid, fromTerminal, toTerminal)
         return this
     }
 
@@ -465,11 +516,21 @@ open class TestNetworkBuilder {
 
     private fun String?.orNextId(type: String): String = this ?: "$type${count++}"
 
-    private fun connect(from: ConductingEquipment, to: ConductingEquipment, fromTerminal: Int? = null, toTerminal: Int? = null) {
-        network.connect(
-            from.getTerminal(fromTerminal ?: currentTerminal ?: from.numTerminals())!!,
-            to.getTerminal(toTerminal ?: 1)!!
-        )
+    private fun connect(
+        from: ConductingEquipment,
+        to: ConductingEquipment,
+        connectivityNodeMrid: String? = null,
+        fromTerminal: Int? = null,
+        toTerminal: Int? = null
+    ) {
+        val fromTerm = from.getTerminal(fromTerminal ?: currentTerminal ?: from.numTerminals())!!
+        val toTerm = to.getTerminal(toTerminal ?: 1)!!
+        if ((connectivityNodeMrid == null) || fromTerm.isConnected || toTerm.isConnected)
+            network.connect(fromTerm, toTerm)
+        else {
+            network.connect(fromTerm, connectivityNodeMrid)
+            network.connect(toTerm, connectivityNodeMrid)
+        }
         currentTerminal = null
     }
 

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -16,6 +16,7 @@ import com.zepben.evolve.cim.iec61970.base.wires.*
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.Tracing
+import kotlin.reflect.full.primaryConstructor
 
 /**
  * A class for building simple test networks, often used for unit testing.
@@ -42,8 +43,8 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun fromSource(phases: PhaseCode = PhaseCode.ABC, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createExternalSource(phases).also(action)
+    fun fromSource(phases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
+        current = network.createExternalSource(mRID, phases).also(action)
         return this
     }
 
@@ -56,8 +57,8 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun toSource(phases: PhaseCode = PhaseCode.ABC, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createExternalSource(phases).also {
+    fun toSource(phases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: EnergySource.() -> Unit = {}): TestNetworkBuilder {
+        current = network.createExternalSource(mRID, phases).also {
             connect(current!!, it)
             action(it)
         }
@@ -73,8 +74,8 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun fromAcls(nominalPhases: PhaseCode = PhaseCode.ABC, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createAcls(nominalPhases).also(action)
+    fun fromAcls(nominalPhases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
+        current = network.createAcls(mRID, nominalPhases).also(action)
         return this
     }
 
@@ -87,8 +88,8 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun toAcls(nominalPhases: PhaseCode = PhaseCode.ABC, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createAcls(nominalPhases).also {
+    fun toAcls(nominalPhases: PhaseCode = PhaseCode.ABC, mRID: String? = null, action: AcLineSegment.() -> Unit = {}): TestNetworkBuilder {
+        current = network.createAcls(mRID, nominalPhases).also {
             connect(current!!, it)
             action(it)
         }
@@ -110,9 +111,10 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         isNormallyOpen: Boolean = false,
         isOpen: Boolean? = null,
+        mRID: String? = null,
         action: Breaker.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createBreaker(nominalPhases, isNormallyOpen = isNormallyOpen, isOpen = isOpen ?: isNormallyOpen).also(action)
+        current = network.createBreaker(mRID, nominalPhases, isNormallyOpen = isNormallyOpen, isOpen = isOpen ?: isNormallyOpen).also(action)
         return this
     }
 
@@ -131,9 +133,10 @@ open class TestNetworkBuilder {
         nominalPhases: PhaseCode = PhaseCode.ABC,
         isNormallyOpen: Boolean = false,
         isOpen: Boolean? = null,
+        mRID: String? = null,
         action: Breaker.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createBreaker(nominalPhases, isNormallyOpen = isNormallyOpen, isOpen = isOpen ?: isNormallyOpen).also {
+        current = network.createBreaker(mRID, nominalPhases, isNormallyOpen = isNormallyOpen, isOpen = isOpen ?: isNormallyOpen).also {
             connect(current!!, it)
             action(it)
         }
@@ -150,8 +153,13 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun fromJunction(nominalPhases: PhaseCode = PhaseCode.ABC, numTerminals: Int? = null, action: Junction.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createJunction(nominalPhases, numTerminals).also(action)
+    fun fromJunction(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        numTerminals: Int? = null,
+        mRID: String? = null,
+        action: Junction.() -> Unit = {}
+    ): TestNetworkBuilder {
+        current = network.createJunction(mRID, nominalPhases, numTerminals).also(action)
         return this
     }
 
@@ -165,8 +173,13 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun toJunction(nominalPhases: PhaseCode = PhaseCode.ABC, numTerminals: Int? = null, action: Junction.() -> Unit = {}): TestNetworkBuilder {
-        current = network.createJunction(nominalPhases, numTerminals).also {
+    fun toJunction(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        numTerminals: Int? = null,
+        mRID: String? = null,
+        action: Junction.() -> Unit = {}
+    ): TestNetworkBuilder {
+        current = network.createJunction(mRID, nominalPhases, numTerminals).also {
             connect(current!!, it)
             action(it)
         }
@@ -186,9 +199,10 @@ open class TestNetworkBuilder {
     fun toPowerElectronicsConnection(
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int = 2,
+        mRID: String? = null,
         action: PowerElectronicsConnection.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createPowerElectronicsConnection(nominalPhases, numTerminals).also {
+        current = network.createPowerElectronicsConnection(mRID, nominalPhases, numTerminals).also {
             connect(current!!, it)
             action(it)
         }
@@ -208,9 +222,10 @@ open class TestNetworkBuilder {
     fun fromPowerTransformer(
         nominalPhases: List<PhaseCode> = listOf(PhaseCode.ABC, PhaseCode.ABC),
         endActions: List<PowerTransformerEnd.() -> Unit>? = null,
+        mRID: String? = null,
         action: PowerTransformer.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createPowerTransformer(nominalPhases).also {
+        current = network.createPowerTransformer(mRID, nominalPhases).also {
             endActions?.forEachIndexed { index, endAction ->
                 endAction(it.ends[index])
             }
@@ -232,9 +247,10 @@ open class TestNetworkBuilder {
     fun toPowerTransformer(
         nominalPhases: List<PhaseCode> = listOf(PhaseCode.ABC, PhaseCode.ABC),
         endActions: List<PowerTransformerEnd.() -> Unit>? = null,
+        mRID: String? = null,
         action: PowerTransformer.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createPowerTransformer(nominalPhases).also {
+        current = network.createPowerTransformer(mRID, nominalPhases).also {
             connect(current!!, it)
             endActions?.forEachIndexed { index, endAction ->
                 endAction(it.ends[index])
@@ -259,11 +275,30 @@ open class TestNetworkBuilder {
         creator: (String) -> ConductingEquipment,
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int? = null,
+        mRID: String? = null,
         action: ConductingEquipment.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createOther(creator, nominalPhases, numTerminals).also(action)
+        current = network.createOther(mRID, creator, nominalPhases, numTerminals).also(action)
         return this
     }
+
+    /**
+     * Start a new network island from a [ConductingEquipment], updating the network pointer to the new [ConductingEquipment].
+     *
+     * @param T The type of object to create.
+     * @param nominalPhases The nominal phases for the new [ConductingEquipment].
+     * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
+     *
+     * @return This [TestNetworkBuilder] to allow for fluent use.
+     */
+    inline fun <reified T : ConductingEquipment> fromOther(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        numTerminals: Int? = null,
+        mRID: String? = null,
+        noinline action: ConductingEquipment.() -> Unit = {}
+    ): TestNetworkBuilder =
+        fromOther({ T::class.primaryConstructor!!.call(it) }, nominalPhases, numTerminals, mRID, action)
 
     /**
      * Add a new [ConductingEquipment] to the network and connect it to the current network pointer, updating the network pointer to the new [ConductingEquipment].
@@ -280,14 +315,33 @@ open class TestNetworkBuilder {
         creator: (String) -> ConductingEquipment,
         nominalPhases: PhaseCode = PhaseCode.ABC,
         numTerminals: Int? = null,
+        mRID: String? = null,
         action: ConductingEquipment.() -> Unit = {}
     ): TestNetworkBuilder {
-        current = network.createOther(creator, nominalPhases, numTerminals).also {
+        current = network.createOther(mRID, creator, nominalPhases, numTerminals).also {
             connect(current!!, it)
             action(it)
         }
         return this
     }
+
+    /**
+     * Add a new [ConductingEquipment] to the network and connect it to the current network pointer, updating the network pointer to the new [ConductingEquipment].
+     *
+     * @param T The type of object to create.
+     * @param nominalPhases The nominal phases for the new [ConductingEquipment].
+     * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
+     *
+     * @return This [TestNetworkBuilder] to allow for fluent use.
+     */
+    inline fun <reified T : ConductingEquipment> toOther(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        numTerminals: Int? = null,
+        mRID: String? = null,
+        noinline action: ConductingEquipment.() -> Unit = {}
+    ): TestNetworkBuilder =
+        toOther({ T::class.primaryConstructor!!.call(it) }, nominalPhases, numTerminals, mRID, action)
 
     /**
      * Move the current network pointer to the specified [from] allowing branching of the network. This has the effect of changing the current network pointer.
@@ -326,8 +380,8 @@ open class TestNetworkBuilder {
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
     @JvmOverloads
-    fun addFeeder(headMrid: String, sequenceNumber: Int? = null): TestNetworkBuilder {
-        network.createFeeder(network[headMrid]!!, sequenceNumber)
+    fun addFeeder(headMrid: String, sequenceNumber: Int? = null, mRID: String? = null): TestNetworkBuilder {
+        network.createFeeder(mRID, network[headMrid]!!, sequenceNumber)
         return this
     }
 
@@ -339,8 +393,8 @@ open class TestNetworkBuilder {
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
-    fun addLvFeeder(headMrid: String, sequenceNumber: Int? = null): TestNetworkBuilder {
-        network.createLvFeeder(network[headMrid]!!, sequenceNumber)
+    fun addLvFeeder(headMrid: String, sequenceNumber: Int? = null, mRID: String? = null): TestNetworkBuilder {
+        network.createLvFeeder(mRID, network[headMrid]!!, sequenceNumber)
         return this
     }
 
@@ -364,7 +418,7 @@ open class TestNetworkBuilder {
         return network
     }
 
-    private fun nextId(type: String): String = "$type${count++}"
+    private fun String?.orNextId(type: String): String = this ?: "$type${count++}"
 
     private fun connect(from: ConductingEquipment, to: ConductingEquipment, fromTerminal: Int? = null, toTerminal: Int? = null) {
         network.connect(
@@ -374,8 +428,8 @@ open class TestNetworkBuilder {
         currentTerminal = null
     }
 
-    private fun NetworkService.createExternalSource(phaseCode: PhaseCode) =
-        nextId("s").let { id ->
+    private fun NetworkService.createExternalSource(mRID: String?, phaseCode: PhaseCode) =
+        mRID.orNextId("s").let { id ->
             if (phaseCode.singlePhases.any { it !in PhaseCode.ABCN })
                 throw IllegalArgumentException("EnergySource phases must be a subset of ABCN")
 
@@ -385,16 +439,16 @@ open class TestNetworkBuilder {
             }.also { add(it) }
         }
 
-    private fun NetworkService.createAcls(phaseCode: PhaseCode) =
-        nextId("c").let { id ->
+    private fun NetworkService.createAcls(mRID: String?, phaseCode: PhaseCode) =
+        mRID.orNextId("c").let { id ->
             AcLineSegment(id).apply {
                 addTerminal(Terminal("$id-t1").apply { phases = phaseCode }.also { add(it) })
                 addTerminal(Terminal("$id-t2").apply { phases = phaseCode }.also { add(it) })
             }.also { add(it) }
         }
 
-    private fun NetworkService.createBreaker(phaseCode: PhaseCode = PhaseCode.ABC, isNormallyOpen: Boolean, isOpen: Boolean) =
-        nextId("b").let { id ->
+    private fun NetworkService.createBreaker(mRID: String?, phaseCode: PhaseCode = PhaseCode.ABC, isNormallyOpen: Boolean, isOpen: Boolean) =
+        mRID.orNextId("b").let { id ->
             Breaker(id).apply {
                 setNormallyOpen(isNormallyOpen)
                 setOpen(isOpen)
@@ -404,24 +458,24 @@ open class TestNetworkBuilder {
             }.also { add(it) }
         }
 
-    private fun NetworkService.createJunction(phaseCode: PhaseCode = PhaseCode.ABC, numTerminals: Int?) =
-        nextId("j").let { id ->
+    private fun NetworkService.createJunction(mRID: String?, phaseCode: PhaseCode = PhaseCode.ABC, numTerminals: Int?) =
+        mRID.orNextId("j").let { id ->
             Junction(id).apply {
                 for (i in 1..(numTerminals ?: 2))
                     addTerminal(Terminal("$id-t$i").apply { phases = phaseCode }.also { add(it) })
             }.also { add(it) }
         }
 
-    private fun NetworkService.createPowerElectronicsConnection(phaseCode: PhaseCode = PhaseCode.ABC, numTerminals: Int?) =
-        nextId("pec").let { id ->
+    private fun NetworkService.createPowerElectronicsConnection(mRID: String?, phaseCode: PhaseCode = PhaseCode.ABC, numTerminals: Int?) =
+        mRID.orNextId("pec").let { id ->
             PowerElectronicsConnection(id).apply {
                 for (i in 1..(numTerminals ?: 2))
                     addTerminal(Terminal("$id-t$i").apply { phases = phaseCode }.also { add(it) })
             }.also { add(it) }
         }
 
-    private fun NetworkService.createPowerTransformer(nominalPhases: List<PhaseCode>) =
-        nextId("tx").let { id ->
+    private fun NetworkService.createPowerTransformer(mRID: String?, nominalPhases: List<PhaseCode>) =
+        mRID.orNextId("tx").let { id ->
             PowerTransformer(id).apply {
                 nominalPhases.forEachIndexed { i, phaseCode ->
                     val t = Terminal("$id-t${i + 1}").apply { phases = phaseCode }.also { add(it) }
@@ -433,19 +487,20 @@ open class TestNetworkBuilder {
         }
 
     private fun NetworkService.createOther(
+        mRID: String?,
         creator: (String) -> ConductingEquipment,
         phaseCode: PhaseCode = PhaseCode.ABC,
         numTerminals: Int?
     ) =
-        nextId("o").let { id ->
+        mRID.orNextId("o").let { id ->
             creator(id).apply {
                 for (i in 1..(numTerminals ?: 2))
-                    addTerminal(Terminal("$mRID-t$i").apply { phases = phaseCode }.also { add(it) })
+                    addTerminal(Terminal("${this.mRID}-t$i").apply { phases = phaseCode }.also { add(it) })
             }.also { tryAdd(it) }
         }
 
-    private fun NetworkService.createFeeder(headEquipment: ConductingEquipment, sequenceNumber: Int?) =
-        nextId("fdr").let { id ->
+    private fun NetworkService.createFeeder(mRID: String?, headEquipment: ConductingEquipment, sequenceNumber: Int?) =
+        mRID.orNextId("fdr").let { id ->
             Feeder(id).apply {
                 normalHeadTerminal = headEquipment.getTerminal(sequenceNumber ?: headEquipment.numTerminals())!!
 
@@ -456,8 +511,8 @@ open class TestNetworkBuilder {
             }
         }
 
-    private fun NetworkService.createLvFeeder(headEquipment: ConductingEquipment, sequenceNumber: Int?) =
-        nextId("lvf").let { id ->
+    private fun NetworkService.createLvFeeder(mRID: String?, headEquipment: ConductingEquipment, sequenceNumber: Int?) =
+        mRID.orNextId("lvf").let { id ->
             LvFeeder(id).apply {
                 normalHeadTerminal = headEquipment.getTerminal(sequenceNumber ?: headEquipment.numTerminals())!!
 

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -38,6 +38,7 @@ open class TestNetworkBuilder {
      * Start a new network island from an [EnergySource], updating the network pointer to the new [EnergySource].
      *
      * @param phases The [PhaseCode] for the new [EnergySource], used as both the nominal and energising phases. Must be a subset of [PhaseCode.ABCN].
+     * @param mRID Optional mRID for the new [EnergySource].
      * @param action An action that accepts the new [EnergySource] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -52,6 +53,7 @@ open class TestNetworkBuilder {
      * Add a new [EnergySource] to the network and connect it to the current network pointer, updating the network pointer to the new [EnergySource].
      *
      * @param phases The [PhaseCode] for the new [EnergySource], used as both the nominal and energising phases. Must be a subset of [PhaseCode.ABCN].
+     * @param mRID Optional mRID for the new [EnergySource].
      * @param action An action that accepts the new [EnergySource] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -69,6 +71,7 @@ open class TestNetworkBuilder {
      * Start a new network island from an [AcLineSegment], updating the network pointer to the new [AcLineSegment].
      *
      * @param nominalPhases The nominal phases for the new [AcLineSegment].
+     * @param mRID Optional mRID for the new [AcLineSegment].
      * @param action An action that accepts the new [AcLineSegment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -83,6 +86,7 @@ open class TestNetworkBuilder {
      * Add a new [AcLineSegment] to the network and connect it to the current network pointer, updating the network pointer to the new [AcLineSegment].
      *
      * @param nominalPhases The nominal phases for the new [AcLineSegment].
+     * @param mRID Optional mRID for the new [AcLineSegment].
      * @param action An action that accepts the new [AcLineSegment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -102,6 +106,7 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [Breaker].
      * @param isNormallyOpen The normal state of the switch. Defaults to false.
      * @param isOpen The current state of the switch. Defaults to [isNormallyOpen].
+     * @param mRID Optional mRID for the new [Breaker].
      * @param action An action that accepts the new [Breaker] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -124,6 +129,7 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [Breaker].
      * @param isNormallyOpen The normal state of the switch. Defaults to false.
      * @param isOpen The current state of the switch. Defaults to [isNormallyOpen].
+     * @param mRID Optional mRID for the new [Breaker].
      * @param action An action that accepts the new [Breaker] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -148,6 +154,7 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for the new [Junction].
      * @param numTerminals The number of terminals to create on the new [Junction]. Defaults to 2.
+     * @param mRID Optional mRID for the new [Junction].
      * @param action An action that accepts the new [Junction] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -168,6 +175,7 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for the new [Junction].
      * @param numTerminals The number of terminals to create on the new [Junction]. Defaults to 2.
+     * @param mRID Optional mRID for the new [Junction].
      * @param action An action that accepts the new [Junction] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -191,6 +199,8 @@ open class TestNetworkBuilder {
      * [PowerElectronicsConnection].
      *
      * @param nominalPhases The nominal phases for the new [PowerElectronicsConnection].
+     * @param numTerminals The number of terminals to create on the new [PowerElectronicsConnection]. Defaults to 2.
+     * @param mRID Optional mRID for the new [PowerElectronicsConnection].
      * @param action An action that accepts the new [PowerElectronicsConnection] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -214,6 +224,7 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for each end of the new [PowerTransformer]. Defaults to two [PhaseCode.ABC] ends.
      * @param endActions Actions that accepts the new [PowerTransformerEnd] to allow for additional initialisation.
+     * @param mRID Optional mRID for the new [PowerTransformer].
      * @param action An action that accepts the new [PowerTransformer] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -239,6 +250,7 @@ open class TestNetworkBuilder {
      *
      * @param nominalPhases The nominal phases for each end of the new [PowerTransformer]. Defaults to two [PhaseCode.ABC] ends.
      * @param endActions Actions that accepts the new [PowerTransformerEnd] to allow for additional initialisation.
+     * @param mRID Optional mRID for the new [PowerTransformer].
      * @param action An action that accepts the new [PowerTransformer] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -266,6 +278,7 @@ open class TestNetworkBuilder {
      * @param creator Creator of the new [ConductingEquipment].
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -288,6 +301,7 @@ open class TestNetworkBuilder {
      * @param T The type of object to create.
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -306,6 +320,7 @@ open class TestNetworkBuilder {
      * @param creator Creator of the new [ConductingEquipment].
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -331,6 +346,7 @@ open class TestNetworkBuilder {
      * @param T The type of object to create.
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
+     * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -347,6 +363,7 @@ open class TestNetworkBuilder {
      * Move the current network pointer to the specified [from] allowing branching of the network. This has the effect of changing the current network pointer.
      *
      * @param from The mRID of the [ConductingEquipment] to branch from.
+     * @param terminal Optional sequence number of the terminal on [from] which will be connected.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
@@ -376,6 +393,7 @@ open class TestNetworkBuilder {
      *
      * @param headMrid The mRID of the head [ConductingEquipment].
      * @param sequenceNumber The [Terminal] sequence number of the head terminal. Defaults to last terminal.
+     * @param mRID Optional mRID for the new [Feeder].
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
@@ -390,6 +408,7 @@ open class TestNetworkBuilder {
      *
      * @param headMrid The mRID of the head [ConductingEquipment].
      * @param sequenceNumber The [Terminal] sequence number of the head terminal. Defaults to last terminal.
+     * @param mRID Optional mRID for the new [LvFeeder].
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
      */
@@ -402,6 +421,9 @@ open class TestNetworkBuilder {
      * Get the [NetworkService] after apply traced phasing, feeder directions, and HV/LV feeder assignment.
      *
      * Does not infer phasing.
+     *
+     * @param applyDirectionsFromSources Indicates if directions should be applied from sources in addition to feeders. This is because test networks typically
+     * are minimal, and having a source is a common start point.
      *
      * @return The [NetworkService] created by this [TestNetworkBuilder]
      */

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -273,6 +273,29 @@ open class TestNetworkBuilder {
     }
 
     /**
+     * Add a new [EnergyConsumer] to the network and connect it to the current network pointer, updating the network pointer to the new
+     * [EnergyConsumer].
+     *
+     * @param nominalPhases The nominal phases for the new [EnergyConsumer].
+     * @param mRID Optional mRID for the new [EnergyConsumer].
+     * @param action An action that accepts the new [EnergyConsumer] to allow for additional initialisation.
+     *
+     * @return This [TestNetworkBuilder] to allow for fluent use.
+     */
+    @JvmOverloads
+    fun toEnergyConsumer(
+        nominalPhases: PhaseCode = PhaseCode.ABC,
+        mRID: String? = null,
+        action: EnergyConsumer.() -> Unit = {}
+    ): TestNetworkBuilder {
+        current = network.createEnergyConsumer(mRID, nominalPhases).also {
+            connect(current!!, it)
+            action(it)
+        }
+        return this
+    }
+
+    /**
      * Start a new network island from a [ConductingEquipment], updating the network pointer to the new [ConductingEquipment].
      *
      * @param creator Creator of the new [ConductingEquipment].
@@ -505,6 +528,13 @@ open class TestNetworkBuilder {
                     addTerminal(t)
                     addEnd(PowerTransformerEnd("$id-e${i + 1}").apply { terminal = t }.also { add(it) })
                 }
+            }.also { add(it) }
+        }
+
+    private fun NetworkService.createEnergyConsumer(mRID: String?, phaseCode: PhaseCode = PhaseCode.ABC) =
+        mRID.orNextId("ec").let { id ->
+            EnergyConsumer(id).apply {
+                addTerminal(Terminal("$id-t1").apply { phases = phaseCode }.also { add(it) })
             }.also { add(it) }
         }
 

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/PhaseCodeTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/PhaseCodeTest.kt
@@ -98,6 +98,36 @@ internal class PhaseCodeTest {
     }
 
     @Test
+    internal fun plus() {
+        assertThat(PhaseCode.A + SinglePhaseKind.B, equalTo(PhaseCode.AB))
+        assertThat(PhaseCode.BC + PhaseCode.AN, equalTo(PhaseCode.ABCN))
+        assertThat(PhaseCode.X + SinglePhaseKind.Y, equalTo(PhaseCode.XY))
+        assertThat(PhaseCode.N + PhaseCode.XY, equalTo(PhaseCode.XYN))
+
+        // Can add existing phases.
+        assertThat(PhaseCode.ABCN + SinglePhaseKind.A, equalTo(PhaseCode.ABCN))
+        assertThat(PhaseCode.ABCN + SinglePhaseKind.B, equalTo(PhaseCode.ABCN))
+        assertThat(PhaseCode.A + PhaseCode.ABCN, equalTo(PhaseCode.ABCN))
+
+        // Returns NONE for invalid additions.
+        assertThat(PhaseCode.ABCN + SinglePhaseKind.X, equalTo(PhaseCode.NONE))
+        assertThat(PhaseCode.ABCN + PhaseCode.X, equalTo(PhaseCode.NONE))
+    }
+
+    @Test
+    internal fun minus() {
+        assertThat(PhaseCode.ABCN - SinglePhaseKind.B, equalTo(PhaseCode.ACN))
+        assertThat(PhaseCode.ABCN - PhaseCode.AN, equalTo(PhaseCode.BC))
+        assertThat(PhaseCode.BC - SinglePhaseKind.C, equalTo(PhaseCode.B))
+        assertThat(PhaseCode.XY - PhaseCode.X, equalTo(PhaseCode.Y))
+
+        assertThat(PhaseCode.X - SinglePhaseKind.Y, equalTo(PhaseCode.X))
+        assertThat(PhaseCode.AB - PhaseCode.C, equalTo(PhaseCode.AB))
+
+        assertThat(PhaseCode.ABCN - PhaseCode.ABCN, equalTo(PhaseCode.NONE))
+    }
+
+    @Test
     internal fun singlePhaseHelpers() {
         assertThat(PhaseCode.ABC.map { "$it-$it" }.toList(), contains("A-A", "B-B", "C-C"))
 

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/SinglePhaseKindTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/SinglePhaseKindTest.kt
@@ -7,8 +7,11 @@
  */
 package com.zepben.evolve.cim.iec61970.base.wires
 
+import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.validateEnum
 import com.zepben.testutils.junit.SystemLogExtension
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import com.zepben.protobuf.cim.iec61970.base.wires.SinglePhaseKind as PBSinglePhaseKind
@@ -22,6 +25,29 @@ internal class SinglePhaseKindTest {
     @Test
     internal fun validateVsPb() {
         validateEnum(SinglePhaseKind.values(), PBSinglePhaseKind.values())
+    }
+
+    @Test
+    internal fun accessors() {
+        // These tests are just to provide coverage and satisfy the IDE visibility checks.
+        assertThat(SinglePhaseKind.A.value, equalTo(1))
+        assertThat(SinglePhaseKind.A.maskIndex, equalTo(0))
+        assertThat(SinglePhaseKind.A.bitMask, equalTo(1))
+    }
+
+    @Test
+    internal fun plus() {
+        assertThat(SinglePhaseKind.A + SinglePhaseKind.B, equalTo(PhaseCode.AB))
+        assertThat(SinglePhaseKind.A + SinglePhaseKind.A, equalTo(PhaseCode.A))
+        assertThat(SinglePhaseKind.A + PhaseCode.BC, equalTo(PhaseCode.ABC))
+    }
+
+    @Test
+    internal fun minus() {
+        assertThat(SinglePhaseKind.B - SinglePhaseKind.A, equalTo(PhaseCode.B))
+        assertThat(SinglePhaseKind.A - SinglePhaseKind.A, equalTo(PhaseCode.NONE))
+        assertThat(SinglePhaseKind.A - PhaseCode.BC, equalTo(PhaseCode.A))
+        assertThat(SinglePhaseKind.A - PhaseCode.ABC, equalTo(PhaseCode.NONE))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityInternalTest.kt
@@ -249,6 +249,52 @@ internal class TerminalConnectivityInternalTest {
         validateTxPaths(PhaseCode.XN, PhaseCode.X)
     }
 
+    @Test
+    internal fun pathsThroughSwerLv2Tx() {
+        validateTxPaths(PhaseCode.A, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.A, PhaseCode.BCN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.A, PhaseCode.ACN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.A, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.B, PhaseCode.ABN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.B, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.B, PhaseCode.ACN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.B, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.C, PhaseCode.ABN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.C, PhaseCode.BCN, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.C, PhaseCode.ACN)
+        validateTxPaths(PhaseCode.C, PhaseCode.XYN)
+
+        validateTxPaths(PhaseCode.X, PhaseCode.ABN)
+        validateTxPaths(PhaseCode.X, PhaseCode.BCN)
+        validateTxPaths(PhaseCode.X, PhaseCode.ACN)
+        validateTxPaths(PhaseCode.X, PhaseCode.XYN)
+    }
+
+    @Test
+    internal fun pathsThroughLv2SwerTx() {
+        validateTxPaths(PhaseCode.ABN, PhaseCode.A)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.B, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.C, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ABN, PhaseCode.X)
+
+        validateTxPaths(PhaseCode.BCN, PhaseCode.A, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.B)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.C, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.BCN, PhaseCode.X)
+
+        validateTxPaths(PhaseCode.ACN, PhaseCode.A, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.B, PhaseCode.NONE)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.C)
+        validateTxPaths(PhaseCode.ACN, PhaseCode.X)
+
+        validateTxPaths(PhaseCode.XYN, PhaseCode.A)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.B)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.C)
+        validateTxPaths(PhaseCode.XYN, PhaseCode.X)
+    }
+
     private fun validateTxPaths(primary: PhaseCode, secondary: PhaseCode, traced: PhaseCode = secondary) {
         val tx = PowerTransformer()
         val primaryTerminal = Terminal().apply { phases = primary }.also { tx.addTerminal(it) }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -117,6 +117,33 @@ class SetDirectionTest {
     }
 
     @Test
+    internal fun `doesn't trace from open feeder heads`() {
+        //
+        // 1 b0 21--c1--21--c2--21 b3 2
+        //
+        val n = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toAcls() // c2
+            .toBreaker(isNormallyOpen = true) // b3
+            .addFeeder("b0", 2)
+            .addFeeder("b3", 1)
+            .network
+
+        SetDirection().run(n)
+        DirectionLogger.trace(n["b0"])
+
+        n.getT("b0", 1).validateDirections(NONE)
+        n.getT("b0", 2).validateDirections(DOWNSTREAM)
+        n.getT("c1", 1).validateDirections(UPSTREAM)
+        n.getT("c1", 2).validateDirections(DOWNSTREAM)
+        n.getT("c2", 1).validateDirections(UPSTREAM)
+        n.getT("c2", 2).validateDirections(DOWNSTREAM)
+        n.getT("b3", 1).validateDirections(UPSTREAM)
+        n.getT("b3", 2).validateDirections(NONE)
+    }
+
+    @Test
     internal fun `stops at zone transformers incase feeder heads are missing`() {
         //
         // 1 b0*21--c1--21 tx2 21--c3--2

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -11,10 +11,7 @@
 
 package com.zepben.evolve.services.network.tracing.feeder
 
-import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Feeder
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.testdata.PhaseSwapLoopNetwork
 import com.zepben.evolve.services.network.tracing.feeder.DirectionValidator.validateDirections
@@ -117,6 +114,33 @@ class SetDirectionTest {
         n.getT("j3", 2).validateDirections(NONE)
         n.getT("c4", 1).validateDirections(NONE)
         n.getT("c4", 2).validateDirections(NONE)
+    }
+
+    @Test
+    internal fun `stops at zone transformers incase feeder heads are missing`() {
+        //
+        // 1 b0*21--c1--21 tx2 21--c3--2
+        //
+        // * = feeder start
+        //
+        val n = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toPowerTransformer { addContainer(Substation()) } // tx2
+            .toAcls() // c3
+            .addFeeder("b0", 2)
+            .build()
+
+        DirectionLogger.trace(n["b0"])
+
+        n.getT("b0", 1).validateDirections(NONE)
+        n.getT("b0", 2).validateDirections(DOWNSTREAM)
+        n.getT("c1", 1).validateDirections(UPSTREAM)
+        n.getT("c1", 2).validateDirections(DOWNSTREAM)
+        n.getT("tx2", 1).validateDirections(UPSTREAM)
+        n.getT("tx2", 2).validateDirections(NONE)
+        n.getT("c3", 1).validateDirections(NONE)
+        n.getT("c3", 2).validateDirections(NONE)
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversals/BasicTraversalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversals/BasicTraversalTest.kt
@@ -69,8 +69,8 @@ class BasicTraversalTest {
             }
 
         t.run(1, true)
-        assertThat<Set<Int>>(visited, containsInAnyOrder(1, 2, 3, 4))
-        assertThat<Set<Int>>(stoppingOn, containsInAnyOrder(3, 4))
+        assertThat(visited, containsInAnyOrder(1, 2, 3, 4))
+        assertThat(stoppingOn, containsInAnyOrder(3, 4))
     }
 
     @Test
@@ -97,6 +97,31 @@ class BasicTraversalTest {
             .run(1, true)
 
         assertThat(stopCalls, contains(1, 1, 1))
+    }
+
+    @Test
+    fun `stop checking actions are triggered correctly`() {
+        // We do not bother with the queue next as we will just prime the queue with what we want to test.
+        val queueNext = BasicTraversal.QueueNext<Int> { _, _ -> }
+
+        val steppedOn = mutableSetOf<Int>()
+        val notStoppingOn = mutableSetOf<Int>()
+        val stoppingOn = mutableSetOf<Int>()
+
+        BasicTraversal(queueNext, BasicQueue.depthFirst(), BasicTracker()).apply {
+            addStopCondition { it >= 3 }
+            addStepAction { steppedOn.add(it) }
+            ifNotStopping { notStoppingOn.add(it) }
+            ifStopping { stoppingOn.add(it) }
+
+            queue.addAll(1, 2, 3, 4)
+
+            run()
+        }
+
+        assertThat(steppedOn, containsInAnyOrder(1, 2, 3, 4))
+        assertThat(notStoppingOn, containsInAnyOrder(1, 2))
+        assertThat(stoppingOn, containsInAnyOrder(3, 4))
     }
 
     private fun validateStoppingOnFirstAsset(t: BasicTraversal<Int>, expectedOrder: List<Int>) {

--- a/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
@@ -8,10 +8,7 @@
 
 package com.zepben.evolve.testing
 
-import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Feeder
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.*
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
@@ -357,6 +354,18 @@ internal class TestNetworkBuilderTest {
             }
     }
 
+    @Test
+    internal fun `can choose the connectivity node id`() {
+        validateConnectivityNodeOverride { mRID, cnMrid -> toBreaker(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toJunction(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toAcls(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toPowerTransformer(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toPowerElectronicsConnection(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toEnergyConsumer(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toSource(mRID = mRID, connectivityNodeMrid = cnMrid) }
+        validateConnectivityNodeOverride { mRID, cnMrid -> toOther<Fuse>(mRID = mRID, connectivityNodeMrid = cnMrid) }
+    }
+
     private fun NetworkService.validateConnections(mRID: String, vararg expectedTerms: List<String>) {
         assertThat(get<ConductingEquipment>(mRID)!!.numTerminals(), equalTo(expectedTerms.size))
         expectedTerms.forEachIndexed { index, expected ->
@@ -393,6 +402,34 @@ internal class TestNetworkBuilderTest {
                 assertThat(end.terminal, equalTo(terminals[index]))
             }
         }
+    }
+
+    private fun validateConnectivityNodeOverride(addWithConnectivityNode: TestNetworkBuilder.(mRID: String, cnMrid: String) -> Unit) {
+        val ns = TestNetworkBuilder()
+            .fromSource() // s0
+            // Connect using a specific connectivity node
+            .apply { addWithConnectivityNode("my1", "specified-cn") }
+            .fromAcls() // c1
+            // Reuse the specific connectivity node, which should connect all 4 items.
+            .apply { addWithConnectivityNode("my2", "specified-cn") }
+            .fromAcls() // c2
+            .fromAcls() // c3
+            // Force connect to the specific connectivity node, which should connect the additional 2 items.
+            .connect("c2", "c3", 2, 1, "specified-cn")
+            .fromAcls() // c4
+            // Force connect using a different connectivity node, which should be overridden due to the `to` terminal being connected.
+            .connect("c2", "c4", 2, 1, "different-cn")
+            .fromAcls() // c5
+            // Force connect using a different connectivity node, which should be overridden due to the `from` terminal being connected.
+            .connect("c5", "c4", 2, 1, "different-cn")
+            .network
+
+        assertThat(
+            ns.get<ConnectivityNode>("specified-cn")!!.terminals.map { it.mRID },
+            containsInAnyOrder("s0-t1", "my1-t1", "c1-t2", "my2-t1", "c2-t2", "c3-t1", "c4-t1", "c5-t2")
+        )
+        // Make sure our overridden connectivity node was not created.
+        assertThat(ns.get<ConnectivityNode>("different-cn"), nullValue())
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
@@ -181,8 +181,10 @@ internal class TestNetworkBuilderTest {
             .toBreaker(mRID = "my breaker 2")
             .fromJunction(mRID = "my junction 1")
             .toJunction(mRID = "my junction 2")
+            .toPowerElectronicsConnection(mRID = "my pec 1")
             .fromPowerTransformer(mRID = "my tx 1")
             .toPowerTransformer(mRID = "my tx 2")
+            .toEnergyConsumer(mRID = "my ec 1")
             .fromOther(::Fuse, mRID = "my other 1")
             .toOther(::Fuse, mRID = "my other 2")
             .build()
@@ -198,8 +200,10 @@ internal class TestNetworkBuilderTest {
                         "my breaker 2",
                         "my junction 1",
                         "my junction 2",
+                        "my pec 1",
                         "my tx 1",
                         "my tx 2",
+                        "my ec 1",
                         "my other 1",
                         "my other 2"
                     )


### PR DESCRIPTION
# Description

* Added support for LV2 below SWER transformers.
* Improved logging when saving a database.
* The `TestNetworkBuilder` has been enhanced with the following features:
    * You can now set the ID's without having to create a customer 'other' creator.
    * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator.
    * Added inbuilt support for `EnergyConsumer`
    * The `to*` and `connect` functions can specify the connectivity node mRID to use.
* Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
* `TraversalQueue` now has `addAll` methods taking either a collection or varargs
* `Traversal` has two new helper methods:
    * `ifNotStopping`: Adds a step action that is only called if the traversal is not stopping on the item.
    * `ifStopping`: Adds a step action that is only called if the traversal is stopping on the item.
* Deprecated old style accessors in favour of Kotlin accessors for `SinglePhaseKind`.
* `SetDirection.run(NetworkService)` will no longer set directions for feeders with a head terminal on an open switch.
* Feeder directions are now stopped at substation transformers in the same way as assigning equipment

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
