### PR TITLE
Ewb 3472 expose database metadata to clients

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="RIGHT_MARGIN" value="160" />
     <JavaCodeStyleSettings>
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />

--- a/changelog.md
+++ b/changelog.md
@@ -21,8 +21,10 @@
 
 ### New Features
 * Updated to evolve-grpc 0.26.0.
-* Updated super-pom to version 0.30.0
+* Updated super-pom to version 0.33.0
 * Added `connectWithIdentity()` for connecting using Azure Managed Identities.
+* Added `getMetadata` to `CustomerConsumerClient`, `DiagramConsumerClient`, and `NetworkConsumerClient`. This returns a `ServiceInfo` containing `DataSource`
+  and version information of the connected service.
 
 ### Enhancements
 * Update docusaurus version and the configuration.

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -359,3 +359,47 @@ service.getUnresolvedReferencesTo(mrid).forEach {
 
 </TabItem>
 </Tabs>
+
+## Service metadata
+
+Metadata about the servers title, version, and data sources can be retrieved via the `getMetadata()` call.
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+ServiceInfo serviceInfo = client.getMetadata();
+
+System.out.println(serviceInfo.title);
+
+System.out.println("Data sources:");
+for (DataSource ds : serviceInfo.dataSources) {
+    System.out.println("  " + ds.title);
+    System.out.println("  " + ds.version);
+    System.out.println("  " + ds.timestamp);
+}
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+val serviceInfo = client.getMetadata()
+
+println("Data sources:")
+serviceInfo.dataSources.forEach {
+    System.out.println("  ${ds.title}");
+    System.out.println("  ${ds.version}");
+    System.out.println("  ${ds.timestamp}");
+}
+```
+
+</TabItem>
+</Tabs>

--- a/src/main/kotlin/com/zepben/evolve/services/common/meta/MetadataTranslations.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/meta/MetadataTranslations.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.common.meta
+
+import com.google.protobuf.Timestamp
+import com.zepben.protobuf.metadata.GetMetadataResponse
+import com.zepben.protobuf.metadata.DataSource as PBDataSource
+import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
+import java.time.Instant
+
+fun PBDataSource.fromPb(): DataSource =
+    DataSource(
+        source,
+        version,
+        Instant.ofEpochSecond(timestamp.seconds, timestamp.nanos.toLong())
+    )
+
+fun DataSource.toPb(): PBDataSource =
+    PBDataSource.newBuilder()
+        .setSource(source)
+        .setVersion(version)
+        .setTimestamp(
+            Timestamp.newBuilder()
+                .setSeconds(timestamp.epochSecond)
+                .setNanos(timestamp.nano)
+        )
+        .build()
+
+fun PBServiceInfo.fromPb(): ServiceInfo =
+    ServiceInfo(
+        title,
+        version,
+        dataSourcesList.map { it.fromPb() }
+    )
+
+fun ServiceInfo.toPb(): PBServiceInfo =
+    PBServiceInfo.newBuilder()
+        .setTitle(title)
+        .setVersion(version)
+        .addAllDataSources(dataSources.map { it.toPb() })
+        .build()

--- a/src/main/kotlin/com/zepben/evolve/services/common/meta/ServiceInfo.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/meta/ServiceInfo.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.common.meta
+
+/**
+ * Metadata for a service containing an identifier and the sources of data used to build the service.
+ *
+ * @property title An identifier for the service.
+ * @property version The version of the service.
+ * @property dataSources A list of the data sources used to build the service.
+ */
+data class ServiceInfo(
+    val title: String,
+    val version: String,
+    val dataSources: List<DataSource>
+)

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/CustomerConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/CustomerConsumerClient.kt
@@ -16,6 +16,8 @@ import com.zepben.evolve.streaming.grpc.GrpcChannel
 import com.zepben.evolve.streaming.grpc.GrpcResult
 import com.zepben.protobuf.cc.*
 import com.zepben.protobuf.cc.CustomerIdentifiedObject.IdentifiedObjectCase.*
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
 import io.grpc.CallCredentials
 import io.grpc.ManagedChannel
 import java.util.concurrent.ExecutorService
@@ -154,4 +156,7 @@ class CustomerConsumerClient @JvmOverloads constructor(
         }
     }
 
+    override fun runGetMetadata(getMetadataRequest: GetMetadataRequest, streamObserver: AwaitableStreamObserver<GetMetadataResponse>) {
+        stub.getMetadata(getMetadataRequest, streamObserver)
+    }
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/DiagramConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/DiagramConsumerClient.kt
@@ -15,6 +15,8 @@ import com.zepben.evolve.streaming.grpc.GrpcChannel
 import com.zepben.evolve.streaming.grpc.GrpcResult
 import com.zepben.protobuf.dc.*
 import com.zepben.protobuf.dc.DiagramIdentifiedObject.IdentifiedObjectCase.*
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
 import io.grpc.CallCredentials
 import io.grpc.ManagedChannel
 import java.util.concurrent.ExecutorService
@@ -148,5 +150,7 @@ class DiagramConsumerClient(
 
         return extractResults.asSequence()
     }
-
+    override fun runGetMetadata(getMetadataRequest: GetMetadataRequest, streamObserver: AwaitableStreamObserver<GetMetadataResponse>) {
+        stub.getMetadata(getMetadataRequest, streamObserver)
+    }
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -13,12 +13,16 @@ import com.zepben.evolve.cim.iec61970.infiec61970.feeder.Loop
 import com.zepben.evolve.services.common.BaseService
 import com.zepben.evolve.services.common.extensions.typeNameAndMRID
 import com.zepben.evolve.services.common.translator.mRID
+import com.zepben.evolve.services.common.translator.toInstant
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.translator.NetworkProtoToCim
 import com.zepben.evolve.services.network.translator.mRID
 import com.zepben.evolve.streaming.get.hierarchy.NetworkHierarchy
 import com.zepben.evolve.streaming.grpc.GrpcChannel
 import com.zepben.evolve.streaming.grpc.GrpcResult
+import com.zepben.protobuf.metadata.DataSource
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
 import com.zepben.protobuf.nc.*
 import com.zepben.protobuf.nc.NetworkIdentifiedObject.IdentifiedObjectCase.*
 import io.grpc.CallCredentials
@@ -73,6 +77,10 @@ class NetworkConsumerClient(
             NetworkConsumerGrpc.newStub(channel.channel).apply { callCredentials?.let { withCallCredentials(it) } },
             executor = Executors.newSingleThreadExecutor()
         )
+
+    override fun runGetMetadata(getMetadataRequest: GetMetadataRequest, streamObserver: AwaitableStreamObserver<GetMetadataResponse>) {
+        stub.getMetadata(getMetadataRequest, streamObserver)
+    }
 
     /**
      * Retrieve the [Equipment] for [equipmentContainer]

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcClient.kt
@@ -56,7 +56,7 @@ abstract class GrpcClient(private val executor: ExecutorService?) : AutoCloseabl
      * Allows a safe RPC call to be made to the server by wrapping [rpcCall] in a try/catch block. Any [Throwable] caught will
      * be passed to all registered error handlers.
      */
-    protected fun <T> tryRpc(rpcCall: () -> T): GrpcResult<T> {
+    internal fun <T> tryRpc(rpcCall: () -> T): GrpcResult<T> {
         return try {
             GrpcResult.of(rpcCall())
         } catch (t: Throwable) {

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/RegulatingCondEqTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/RegulatingCondEqTest.kt
@@ -9,7 +9,9 @@ package com.zepben.evolve.cim.iec61970.base.wires
 
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.testdata.fillFields
+import com.zepben.testutils.exception.ExpectException.Companion.expect
 import com.zepben.testutils.junit.SystemLogExtension
+import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -38,5 +40,17 @@ internal class RegulatingCondEqTest {
 
         assertThat(regulatingCondEq.controlEnabled, equalTo(false))
         assertThat(regulatingCondEq.regulatingControl, notNullValue())
+    }
+
+    @Test
+    internal fun cannotChangeRegulatingControl() {
+        val regulatingCondEq = object : RegulatingCondEq() {}
+        val regControl = mockk<RegulatingControl>()
+        regulatingCondEq.regulatingControl = regControl
+
+        expect {
+            regulatingCondEq.regulatingControl = mockk()
+        }.toThrow<IllegalStateException>().withMessage("regulatingControl has already been set to $regControl. Cannot set this field again")
+        assertThat(regulatingCondEq.regulatingControl, equalTo(regControl))
     }
 }

--- a/src/test/kotlin/com/zepben/evolve/services/common/meta/MetadataTranslationsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/common/meta/MetadataTranslationsTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.common.meta
+
+import com.google.protobuf.Timestamp as PBTimestamp
+import io.mockk.*
+import com.zepben.protobuf.metadata.DataSource as PBDataSource
+import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.Matchers.contains
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class MetadataTranslationsTest {
+
+    @Test
+    fun `DataSource from Protobuf`() {
+        val timestampFromPb = mockk<PBTimestamp>().also {
+            every { it.seconds } returns 123L
+            every { it.nanos } returns 456
+        }
+        val dataSourceFromPb = mockk<PBDataSource>().also {
+            every { it.source } returns "source one"
+            every { it.version } returns "version one"
+            every { it.timestamp } returns timestampFromPb
+        }
+
+        val result = dataSourceFromPb.fromPb()
+
+        verifySequence {
+            dataSourceFromPb.source
+            dataSourceFromPb.version
+            dataSourceFromPb.timestamp
+            timestampFromPb.seconds
+            dataSourceFromPb.timestamp
+            timestampFromPb.nanos
+        }
+
+        assertThat(result, isA(DataSource::class.java))
+        assertThat(result.source, equalTo("source one"))
+        assertThat(result.version, equalTo("version one"))
+        assertThat(result.timestamp, equalTo(Instant.ofEpochSecond(123L, 456L)))
+    }
+
+    @Test
+    fun `DataSource to Protobuf`() {
+        val timestamp = mockk<Instant> {
+            every { epochSecond } returns 123L
+            every { nano } returns 456
+        }
+        val dataSourceToPb = mockk<DataSource>().also {
+            every { it.source } returns "test source"
+            every { it.version } returns "test version"
+            every { it.timestamp } returns timestamp
+        }
+
+        val result = dataSourceToPb.toPb()
+
+        verifySequence {
+            dataSourceToPb.source
+            dataSourceToPb.version
+            dataSourceToPb.timestamp
+            timestamp.epochSecond
+            dataSourceToPb.timestamp
+            timestamp.nano
+        }
+
+        assertThat(result, isA(PBDataSource::class.java))
+        assertThat(result.source, equalTo("test source"))
+        assertThat(result.version, equalTo("test version"))
+        assertThat(result.timestamp.seconds, equalTo(123L))
+        assertThat(result.timestamp.nanos, equalTo(456))
+    }
+
+    @Test
+    fun `ServiceInfo to Protobuf`() {
+        val dataSourceOne = mockk<DataSource>()
+        val dataSourceTwo = mockk<DataSource>()
+        val dataSources = listOf(dataSourceOne, dataSourceTwo)
+
+        val serviceInfo = mockk<ServiceInfo>().also {
+            every { it.title } returns "test title"
+            every { it.version } returns "test version"
+            every { it.dataSources } returns dataSources
+        }
+
+        val pbServiceInfo = mockk<PBServiceInfo>()
+        val pbServiceInfoBuilder = mockk<PBServiceInfo.Builder>().also {
+            every { it.setTitle(any()) } returns it
+            every { it.setVersion(any()) } returns it
+            every { it.addAllDataSources(any()) } returns it
+            every { it.build() } returns pbServiceInfo
+        }
+
+        try {
+            mockkStatic(PBServiceInfo::class)
+            mockkStatic(DataSource::toPb)
+            excludeRecords {
+                serviceInfo.toPb()
+            }
+            every { any<DataSource>().toPb() } returns PBDataSource.newBuilder().build()
+            every { PBServiceInfo.newBuilder() } returns pbServiceInfoBuilder
+
+            val result = serviceInfo.toPb()
+
+            verifySequence {
+                pbServiceInfoBuilder.setTitle("test title")
+                pbServiceInfoBuilder.setVersion("test version")
+                dataSourceOne.toPb()
+                dataSourceTwo.toPb()
+                pbServiceInfoBuilder.addAllDataSources(listOf(PBDataSource.newBuilder().build(), PBDataSource.newBuilder().build()))
+                pbServiceInfoBuilder.build()
+            }
+            verify {
+                pbServiceInfo wasNot called // verify here because the following assert will call equals against it
+            }
+            assertThat(result, equalTo(pbServiceInfo))
+        } finally {
+            unmockkStatic(PBServiceInfo::class)
+            unmockkStatic(DataSource::toPb)
+        }
+    }
+
+    @Test
+    fun `ServiceInfo from protobuf`() {
+        val dataSourceOne = mockk<PBDataSource>()
+        val dataSourceTwo = mockk<PBDataSource>()
+        val dataSourceList = listOf(dataSourceOne, dataSourceTwo)
+
+        val pbServiceInfo = mockk<PBServiceInfo> {
+            every { title } returns "mock title"
+            every { version } returns "mock version"
+            every { dataSourcesList } returns dataSourceList
+        }
+        mockkStatic(PBDataSource::fromPb) {
+            excludeRecords {
+                pbServiceInfo.fromPb()
+            }
+            val ds1 = mockk<DataSource>()
+            val ds2 = mockk<DataSource>()
+            every { dataSourceOne.fromPb() } returns ds1
+            every { dataSourceTwo.fromPb() } returns ds2
+
+            val result = pbServiceInfo.fromPb()
+
+            verifySequence {
+                pbServiceInfo.title
+                pbServiceInfo.version
+                pbServiceInfo.dataSourcesList
+                dataSourceOne.fromPb()
+                dataSourceTwo.fromPb()
+            }
+
+            assertThat(result, isA(ServiceInfo::class.java))
+            assertThat(result.title, equalTo("mock title"))
+            assertThat(result.version, equalTo("mock version"))
+            assertThat(result.dataSources, contains(ds1, ds2))
+        }
+    }
+}

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/CimConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/CimConsumerClientTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.streaming.get
+
+import com.zepben.evolve.services.common.BaseService
+import com.zepben.evolve.services.common.meta.ServiceInfo
+import com.zepben.evolve.services.common.meta.fromPb
+import com.zepben.evolve.services.common.translator.BaseProtoToCim
+import com.zepben.evolve.streaming.grpc.GrpcResult
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
+import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
+import io.mockk.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.jupiter.api.Test
+
+class TestCimConsumerClient {
+
+    private val baseConsumerClient = mockk<CimConsumerClient<BaseService, BaseProtoToCim>>()
+
+    @Test
+    fun `getMetaData returns non-cached response, and caches it`() {
+        val metadataResponse = GetMetadataResponse.newBuilder().apply {
+            serviceInfoBuilder.apply {
+                title = "test title"
+                version = "test version"
+                addDataSourcesBuilder().apply {
+                    source = "source one"
+                    version = "source version"
+                    timestamp = timestampBuilder.apply {
+                        seconds = 123L
+                        nanos = 456
+                    }.build()
+                }
+                addDataSourcesBuilder().apply {
+                    source = "source two"
+                    version = "source version two"
+                    timestamp = timestampBuilder.apply {
+                        seconds = 654L
+                        nanos = 321
+                    }.build()
+                }
+            }.build()
+        }.build()
+
+        val returnedServiceInfo = metadataResponse.serviceInfo.fromPb()
+
+        every { baseConsumerClient.runGetMetadata(ofType(GetMetadataRequest::class), any<AwaitableStreamObserver<GetMetadataResponse>>()) } answers {
+            secondArg<AwaitableStreamObserver<GetMetadataResponse>>().onNext(metadataResponse)
+            secondArg<AwaitableStreamObserver<GetMetadataResponse>>().onCompleted()
+        }
+
+        every { baseConsumerClient.getMetadata() } answers { callOriginal() }
+        every { baseConsumerClient.tryRpc<ServiceInfo>(any<() -> ServiceInfo>()) } answers {
+            GrpcResult.of(firstArg<() -> ServiceInfo>().invoke())
+        }
+
+        //Because serviceInfo was made internal for other testing, everyone else has to mockk it themselves...
+        every { baseConsumerClient.serviceInfo } returns null
+        every { baseConsumerClient.serviceInfo = any() } answers {
+            every { baseConsumerClient.serviceInfo } returns firstArg()
+        }
+
+        mockkStatic(PBServiceInfo::fromPb) {
+            every { any<PBServiceInfo>().fromPb() } returns returnedServiceInfo
+            val result = baseConsumerClient.getMetadata()
+
+            verifySequence {
+                baseConsumerClient.getMetadata()
+                baseConsumerClient.tryRpc<GrpcResult<ServiceInfo>>(any())
+                baseConsumerClient.serviceInfo
+                baseConsumerClient.runGetMetadata(GetMetadataRequest.newBuilder().build(), any())
+                metadataResponse.serviceInfo.fromPb()
+                baseConsumerClient.serviceInfo = returnedServiceInfo //verify response cached
+                baseConsumerClient.serviceInfo
+            }
+            assertThat(result.value, equalTo(returnedServiceInfo))
+            assertThat(baseConsumerClient.serviceInfo, equalTo(returnedServiceInfo))
+        }
+    }
+
+    @Test
+    fun `getMetaData returns cached response`() {
+        val uncachedServiceInfo = mockk<ServiceInfo>()
+
+        val cachedResponse = PBServiceInfo.newBuilder().apply {
+            title = "cached title"
+            version = "cached version"
+            addDataSourcesBuilder().apply {
+                source = "source cached"
+                version = "source cached"
+                timestamp = timestampBuilder.apply {
+                    seconds = 123L
+                    nanos = 456
+                }.build()
+            }
+        }.build().fromPb()
+
+        every { baseConsumerClient.serviceInfo } returns cachedResponse
+
+        every { baseConsumerClient.getMetadata() } answers { callOriginal() }
+        every { baseConsumerClient.tryRpc<ServiceInfo>(any<() -> ServiceInfo>()) } answers {
+            GrpcResult.of(firstArg<() -> ServiceInfo>().invoke())
+        }
+        mockkStatic(PBServiceInfo::fromPb) {
+            every { any<PBServiceInfo>().fromPb() } returns uncachedServiceInfo
+            val result = baseConsumerClient.getMetadata()
+
+            verifySequence {
+                baseConsumerClient.getMetadata()
+                baseConsumerClient.tryRpc<GrpcResult<ServiceInfo>>(any())
+                baseConsumerClient.serviceInfo
+                baseConsumerClient.serviceInfo
+            }
+            verify {
+                any<PBServiceInfo>().fromPb() wasNot called
+                uncachedServiceInfo wasNot called
+            }
+            assertThat(result.value, equalTo(cachedResponse))
+        }
+    }
+}

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestDiagramConsumerService.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestDiagramConsumerService.kt
@@ -9,12 +9,16 @@
 package com.zepben.evolve.streaming.get.testservices
 
 import com.zepben.protobuf.dc.*
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
+import io.grpc.Status
 import io.grpc.stub.StreamObserver
 
 class TestDiagramConsumerService : DiagramConsumerGrpc.DiagramConsumerImplBase() {
 
     lateinit var onGetIdentifiedObjects: (request: GetIdentifiedObjectsRequest, response: StreamObserver<GetIdentifiedObjectsResponse>) -> Unit
     lateinit var onGetDiagramObjects: (request: GetDiagramObjectsRequest, response: StreamObserver<GetDiagramObjectsResponse>) -> Unit
+    lateinit var onGetMetadataRequest: (request: GetMetadataRequest, response: StreamObserver<GetMetadataResponse>) -> Unit
 
     override fun getIdentifiedObjects(response: StreamObserver<GetIdentifiedObjectsResponse>): StreamObserver<GetIdentifiedObjectsRequest> =
         TestStreamObserver(response, onGetIdentifiedObjects)
@@ -22,4 +26,16 @@ class TestDiagramConsumerService : DiagramConsumerGrpc.DiagramConsumerImplBase()
     override fun getDiagramObjects(responseObserver: StreamObserver<GetDiagramObjectsResponse>?): StreamObserver<GetDiagramObjectsRequest> =
         TestStreamObserver(responseObserver!!, onGetDiagramObjects)
 
+    override fun getMetadata(request: GetMetadataRequest, responseObserver: StreamObserver<GetMetadataResponse>) {
+        runGrpc(request, responseObserver, onGetMetadataRequest)
+    }
+
+    private fun <T, U : StreamObserver<*>> runGrpc(request: T, response: U, handler: (T, U) -> Unit) {
+        try {
+            handler(request, response)
+            response.onCompleted()
+        } catch (t: Throwable) {
+            response.onError(Status.ABORTED.withDescription(t.message).asRuntimeException())
+        }
+    }
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestNetworkConsumerService.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestNetworkConsumerService.kt
@@ -8,6 +8,8 @@
 
 package com.zepben.evolve.streaming.get.testservices
 
+import com.zepben.protobuf.metadata.GetMetadataRequest
+import com.zepben.protobuf.metadata.GetMetadataResponse
 import com.zepben.protobuf.nc.*
 import io.grpc.Status
 import io.grpc.stub.StreamObserver
@@ -20,12 +22,17 @@ class TestNetworkConsumerService : NetworkConsumerGrpc.NetworkConsumerImplBase()
     lateinit var onGetCurrentEquipmentForFeeder: (request: GetCurrentEquipmentForFeederRequest, response: StreamObserver<GetCurrentEquipmentForFeederResponse>) -> Unit
     lateinit var onGetEquipmentForRestriction: (request: GetEquipmentForRestrictionRequest, response: StreamObserver<GetEquipmentForRestrictionResponse>) -> Unit
     lateinit var onGetTerminalsForNode: (request: GetTerminalsForNodeRequest, response: StreamObserver<GetTerminalsForNodeResponse>) -> Unit
+    lateinit var onGetMetadataRequest: (request: GetMetadataRequest, response: StreamObserver<GetMetadataResponse>) -> Unit
 
     override fun getIdentifiedObjects(response: StreamObserver<GetIdentifiedObjectsResponse>): StreamObserver<GetIdentifiedObjectsRequest> =
         TestStreamObserver(response, onGetIdentifiedObjects)
 
     override fun getNetworkHierarchy(request: GetNetworkHierarchyRequest, response: StreamObserver<GetNetworkHierarchyResponse>) {
         runGrpc(request, response, onGetNetworkHierarchy)
+    }
+
+    override fun getMetadata(request: GetMetadataRequest, response: StreamObserver<GetMetadataResponse>) {
+        runGrpc(request, response, onGetMetadataRequest)
     }
 
     override fun getEquipmentForContainers(response: StreamObserver<GetEquipmentForContainersResponse>): StreamObserver<GetEquipmentForContainersRequest> =


### PR DESCRIPTION
# Description

Adds `getMetadata()` gRPC calls to Customer/Diagram/Network consumer clients. 

# Associated tasks

Relies on:
https://github.com/zepben/evolve-grpc/pull/80

Required for:
https://github.com/zepben/ewb-network-routes/pull/125
https://github.com/zepben/energy-workbench-server/pull/126
https://github.com/zepben/ewb-network-server/pull/58

Python sdk:
https://github.com/zepben/evolve-sdk-python/pull/135



# Checklist

If any of these are not applicable, strikethrough the line `~~like this~~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).

