### PR TITLE
EWB-4098: Update super pom to 0.34.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben EWB SDK changelog
 ## [0.18.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Updated to super-pom version 0.34.x.
 
 ### New Features
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.34.0</version>
+        <version>0.34.1</version>
     </parent>
 
     <groupId>com.zepben</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.33.0</version>
+        <version>0.34.0</version>
     </parent>
 
     <groupId>com.zepben</groupId>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.zepben.evolve</groupId>
             <artifactId>evolve-conn</artifactId>
-            <version>0.7.0</version>
+            <version>0.8.0-SNAPSHOT1</version>
         </dependency>
 
         <!-- Kotlin -->
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.zepben</groupId>
             <artifactId>test-utils</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0-SNAPSHOT2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Description

Use super pom version 0.34.1, fixing transient vulnerabilities from evolve-conn-jvm and test-utils.

# Associated tasks

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-super-pom/pull/36
- [x] https://github.com/zepben/evolve-conn-jvm/pull/12
- [x] https://github.com/zepben/test-utils-jvm/pull/4

Tasks this is blocking:
- https://github.com/zepben/network-verifier-lib/pull/35
- https://github.com/zepben/ewb-network-routes/pull/127
- https://github.com/zepben/power-factory-exporter/pull/76
- https://github.com/zepben/opendss-exporter-jvm/pull/27
- https://github.com/zepben/hosting-capacity-service/pull/13

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ (Version changes did not break tests)
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Updates Vert.x major version (3 -> 4).