### PR TITLE
Ewb 4287 set higher max protobuf message size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,13 +4,13 @@
 * None.
 
 ### New Features
-* None.
+* Allow setting gRPC `maxInboundMessageSize` via `GrpcChannelBuilder.build`.
 
 ### Enhancements
 * None.
 
 ### Fixes
-* None.
+* Accept larger protobuf messages up to 20MB in size by default.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
@@ -15,6 +15,8 @@ import io.grpc.TlsChannelCredentials
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import java.io.File
 
+private const val TWENTY_MEGABYTES = 1024 * 1024 * 20
+
 /**
  * Builder class for GrpcChannel. Allows easy specification of channel credentials via SSL/TLS
  * and call credentials via a ZepbenTokenFetcher.
@@ -26,7 +28,7 @@ class GrpcChannelBuilder {
     private var _channelCredentials: ChannelCredentials? = null
     private var _callCredentials: CallCredentials? = null
 
-    fun build(maxInboundMessageSize: Int = 20000000): GrpcChannel = GrpcChannel(
+    fun build(maxInboundMessageSize: Int = TWENTY_MEGABYTES): GrpcChannel = GrpcChannel(
         _channelCredentials?.let { channelCreds ->
             val channelBuilder = NettyChannelBuilder.forAddress(_host, _port, channelCreds).maxInboundMessageSize(maxInboundMessageSize)
             _callCredentials?.let { callCreds ->

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
@@ -26,13 +26,13 @@ class GrpcChannelBuilder {
     private var _channelCredentials: ChannelCredentials? = null
     private var _callCredentials: CallCredentials? = null
 
-    fun build(): GrpcChannel = GrpcChannel(
+    fun build(maxInboundMessageSize: Int = 20000000): GrpcChannel = GrpcChannel(
         _channelCredentials?.let { channelCreds ->
-            val channelBuilder = NettyChannelBuilder.forAddress(_host, _port, channelCreds)
+            val channelBuilder = NettyChannelBuilder.forAddress(_host, _port, channelCreds).maxInboundMessageSize(maxInboundMessageSize)
             _callCredentials?.let { callCreds ->
                 channelBuilder.intercept(CallCredentialApplier(callCreds)).build()
             } ?: channelBuilder.build()
-        } ?: NettyChannelBuilder.forAddress(_host, _port).usePlaintext().build()
+        } ?: NettyChannelBuilder.forAddress(_host, _port).usePlaintext().maxInboundMessageSize(maxInboundMessageSize).build()
     )
 
     fun forAddress(

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -29,6 +29,35 @@ internal class GrpcChannelBuilderTest {
     }
 
     @Test
+    internal fun `test max inbound message size is set`() {
+        val insecureChannel = mockk<ManagedChannel>()
+
+        mockkStatic(NettyChannelBuilder::class)
+        every { NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(any()).build() } returns insecureChannel
+
+        var grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).build(2000)
+
+        verify {
+            NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(2000)
+        }
+        assertThat(grpcChannel.channel, equalTo(insecureChannel))
+
+        grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).build()
+
+        verify {
+            NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(20000000)
+        }
+        assertThat(grpcChannel.channel, equalTo(insecureChannel))
+
+        grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).build(0)
+
+        verify {
+            NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(0)
+        }
+        assertThat(grpcChannel.channel, equalTo(insecureChannel))
+    }
+
+    @Test
     internal fun forAddress() {
         val insecureChannel = mockk<ManagedChannel>()
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -45,7 +45,7 @@ internal class GrpcChannelBuilderTest {
         grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).build()
 
         verify {
-            NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(20000000)
+            NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(20971520)
         }
         assertThat(grpcChannel.channel, equalTo(insecureChannel))
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -33,7 +33,7 @@ internal class GrpcChannelBuilderTest {
         val insecureChannel = mockk<ManagedChannel>()
 
         mockkStatic(NettyChannelBuilder::class)
-        every { NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().build() } returns insecureChannel
+        every { NettyChannelBuilder.forAddress("hostname", 1234).usePlaintext().maxInboundMessageSize(any()).build() } returns insecureChannel
 
         val grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).build()
         assertThat(grpcChannel.channel, equalTo(insecureChannel))
@@ -49,7 +49,7 @@ internal class GrpcChannelBuilderTest {
         every { TlsChannelCredentials.newBuilder().trustManager(caFile).build() } returns channelCredentials
 
         mockkStatic(NettyChannelBuilder::class)
-        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).build() } returns secureChannel
+        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).maxInboundMessageSize(any()).build() } returns secureChannel
 
         val grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).makeSecure(caFile).build()
         assertThat(grpcChannel.channel, equalTo(secureChannel))
@@ -64,7 +64,7 @@ internal class GrpcChannelBuilderTest {
         every { TlsChannelCredentials.create() } returns channelCredentials
 
         mockkStatic(NettyChannelBuilder::class)
-        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).build() } returns secureChannel
+        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).maxInboundMessageSize(any()).build() } returns secureChannel
 
         val grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).makeSecure().build()
         assertThat(grpcChannel.channel, equalTo(secureChannel))
@@ -83,7 +83,7 @@ internal class GrpcChannelBuilderTest {
         every { TlsChannelCredentials.newBuilder().keyManager(certChainFile, pkFile).build() } returns channelCredentials
 
         mockkStatic(NettyChannelBuilder::class)
-        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).build() } returns secureChannel
+        every { NettyChannelBuilder.forAddress("hostname", 1234, channelCredentials).maxInboundMessageSize(any()).build() } returns secureChannel
 
         assertThat(GrpcChannelBuilder().forAddress("hostname", 1234).makeSecure(caFile, certChainFile, pkFile).build().channel, equalTo(secureChannel))
         assertThat(GrpcChannelBuilder().forAddress("hostname", 1234).makeSecure(certificateChain = certChainFile, privateKey = pkFile).build().channel, equalTo(secureChannel))
@@ -107,7 +107,7 @@ internal class GrpcChannelBuilderTest {
         val authenticatedChannel = mockk<ManagedChannel>()
 
         mockkStatic(NettyChannelBuilder::class)
-        every { NettyChannelBuilder.forAddress("hostname", 1234, any()).intercept(any<CallCredentialApplier>()).build() } returns authenticatedChannel
+        every { NettyChannelBuilder.forAddress("hostname", 1234, any()).maxInboundMessageSize(any()).intercept(any<CallCredentialApplier>()).build() } returns authenticatedChannel
 
         val tokenFetcher = ZepbenTokenFetcher("audience", "domain", AuthMethod.AUTH0)
         val grpcChannel = GrpcChannelBuilder().forAddress("hostname", 1234).makeSecure().withTokenFetcher(tokenFetcher).build()


### PR DESCRIPTION
# Description

EE network hierarchy protobuf message is larger than the max gRPC default message size of 4mb. I've increased our channel builder to default to a max message size of 20mb, and made it configurable via the `build()` call.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).
