### PR TITLE
DEV-639: Add FeederTotal and SubstationTotal network levels

### DIFF
--- a/docs/docs/metrics.mdx
+++ b/docs/docs/metrics.mdx
@@ -78,7 +78,8 @@ public class IngestionJobExample {
         ingestionJob.getSources().get("ABC_feeder.xml").setTimestamp(Instant.parse("2020-01-02T10:30:00.00Z"));
         ingestionJob.getSources().get("ABC_feeder.xml").setFileHash(digest.digest("file contents".getBytes()));
         ingestionJob.getNetworkMetrics().get(TotalNetworkContainer.INSTANCE).put("total cable length", 123.45);
-        ingestionJob.getNetworkMetrics().get(networkContainer(feeder)).put("total cable length", 123.45);
+        ingestionJob.getNetworkMetrics().get(networkContainer(feeder)).put("total cable length", 12.345);
+        ingestionJob.getNetworkMetrics().get(networkContainer(feeder, true)).put("total cable length", 123.45);
 
         if (new MetricsDatabaseWriter("metrics.sqlite", ingestionJob).save()) {
             System.out.println("Ingestion job saved successfully");
@@ -118,7 +119,8 @@ val ingestionJob = IngestionJob(UUID.randomUUID()).apply {
     sources["ABC_feeder.xml"].timestamp = Instant.parse("2020-01-02T10:30:00.00Z")
     sources["ABC_feeder.xml"].fileHash = MessageDigest.getInstance("SHA-256").digest("file contents".toByteArray())
     networkMetrics[TotalNetworkContainer]["total cable length"] = 123.45
-    networkMetrics[feeder.toNetworkContainer()]["total cable length"] = 123.45
+    networkMetrics[feeder.toNetworkContainer()]["total cable length"] = 12.345
+    networkMetrics[feeder.toNetworkContainer(includeDownstream = true)]["total cable length"] = 123.45
 }
 
 fun main() {

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/tables/TableNetworkContainerMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/tables/TableNetworkContainerMetrics.kt
@@ -21,11 +21,11 @@ class TableNetworkContainerMetrics : MultiJobTable() {
     val METRIC_VALUE: Column = Column(++columnIndex, "metric_value", "NUMBER", NOT_NULL)
 
     override val uniqueIndexColumns: MutableList<List<Column>> = mutableListOf(
-        listOf(JOB_ID, HIERARCHY_ID, METRIC_NAME)
+        listOf(JOB_ID, HIERARCHY_ID, CONTAINER_TYPE, METRIC_NAME)
     )
 
     override val nonUniqueIndexColumns: MutableList<List<Column>> = mutableListOf(
-        listOf(HIERARCHY_ID, METRIC_NAME)
+        listOf(HIERARCHY_ID, CONTAINER_TYPE, METRIC_NAME)
     )
 
     override val name: String = "network_container_metrics"

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainer.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainer.kt
@@ -31,7 +31,9 @@ enum class NetworkLevel {
     GeographicalRegion,
     SubGeographicalRegion,
     Substation,
+    SubstationTotal,
     Feeder,
+    FeederTotal,
     LvFeeder
 }
 
@@ -39,16 +41,22 @@ fun GeographicalRegion.toNetworkContainer(): PartialNetworkContainer =
     PartialNetworkContainer(NetworkLevel.GeographicalRegion, mRID, name)
 fun SubGeographicalRegion.toNetworkContainer(): PartialNetworkContainer =
     PartialNetworkContainer(NetworkLevel.SubGeographicalRegion, mRID, name)
-fun Substation.toNetworkContainer(): PartialNetworkContainer =
-    PartialNetworkContainer(NetworkLevel.Substation, mRID, name)
-fun Feeder.toNetworkContainer(): PartialNetworkContainer =
-    PartialNetworkContainer(NetworkLevel.Feeder, mRID, name)
+fun Substation.toNetworkContainer(includeDownstream: Boolean = false): PartialNetworkContainer =
+    PartialNetworkContainer(if (includeDownstream) NetworkLevel.SubstationTotal else NetworkLevel.Substation, mRID, name)
+fun Feeder.toNetworkContainer(includeDownstream: Boolean = false): PartialNetworkContainer =
+    PartialNetworkContainer(if (includeDownstream) NetworkLevel.FeederTotal else NetworkLevel.Feeder, mRID, name)
 fun LvFeeder.toNetworkContainer(): PartialNetworkContainer =
     PartialNetworkContainer(NetworkLevel.LvFeeder, mRID, name)
 
 // Java interop
 fun networkContainer(geographicalRegion: GeographicalRegion) = geographicalRegion.toNetworkContainer()
+
 fun networkContainer(subGeographicalRegion: SubGeographicalRegion) = subGeographicalRegion.toNetworkContainer()
-fun networkContainer(substation: Substation) = substation.toNetworkContainer()
-fun networkContainer(feeder: Feeder) = feeder.toNetworkContainer()
+
+@JvmOverloads
+fun networkContainer(substation: Substation, includeDownstream: Boolean = false) = substation.toNetworkContainer(includeDownstream)
+
+@JvmOverloads
+fun networkContainer(feeder: Feeder, includeDownstream: Boolean = false) = feeder.toNetworkContainer(includeDownstream)
+
 fun networkContainer(lvFeeder: LvFeeder) = lvFeeder.toNetworkContainer()

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerKtTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerKtTest.kt
@@ -24,13 +24,17 @@ internal class NetworkContainerTest {
         val fromGeoRegion = GeographicalRegion("GR").apply { name = "geoRegion" }.toNetworkContainer()
         val fromSubGeoRegion = SubGeographicalRegion("SGR").apply { name = "subGeoRegion" }.toNetworkContainer()
         val fromSubstation = Substation("SS").apply { name = "substation" }.toNetworkContainer()
+        val fromSubstationTotal = Substation("SS2").apply { name = "substation2" }.toNetworkContainer(includeDownstream = true)
         val fromFeeder = Feeder("FDR").apply { name = "feeder" }.toNetworkContainer()
+        val fromFeederTotal = Feeder("FDR2").apply { name = "feeder2" }.toNetworkContainer(includeDownstream = true)
         val fromLvFeeder = LvFeeder("LVF").apply { name = "lvFeeder" }.toNetworkContainer()
 
         assertThat(fromGeoRegion, equalTo(PartialNetworkContainer(NetworkLevel.GeographicalRegion, "GR", "geoRegion")))
         assertThat(fromSubGeoRegion, equalTo(PartialNetworkContainer(NetworkLevel.SubGeographicalRegion, "SGR", "subGeoRegion")))
         assertThat(fromSubstation, equalTo(PartialNetworkContainer(NetworkLevel.Substation, "SS", "substation")))
+        assertThat(fromSubstationTotal, equalTo(PartialNetworkContainer(NetworkLevel.SubstationTotal, "SS2", "substation2")))
         assertThat(fromFeeder, equalTo(PartialNetworkContainer(NetworkLevel.Feeder, "FDR", "feeder")))
+        assertThat(fromFeederTotal, equalTo(PartialNetworkContainer(NetworkLevel.FeederTotal, "FDR2", "feeder2")))
         assertThat(fromLvFeeder, equalTo(PartialNetworkContainer(NetworkLevel.LvFeeder, "LVF", "lvFeeder")))
     }
 
@@ -47,13 +51,17 @@ internal class NetworkContainerTest {
         val fromGeoRegion = networkContainer(GeographicalRegion("GR").apply { name = "geoRegion" })
         val fromSubGeoRegion = networkContainer(SubGeographicalRegion("SGR").apply { name = "subGeoRegion" })
         val fromSubstation = networkContainer(Substation("SS").apply { name = "substation" })
+        val fromSubstationTotal = networkContainer(Substation("SS2").apply { name = "substation2" }, true)
         val fromFeeder = networkContainer(Feeder("FDR").apply { name = "feeder" })
+        val fromFeederTotal = networkContainer(Feeder("FDR2").apply { name = "feeder2" }, true)
         val fromLvFeeder = networkContainer(LvFeeder("LVF").apply { name = "lvFeeder" })
 
         assertThat(fromGeoRegion, equalTo(PartialNetworkContainer(NetworkLevel.GeographicalRegion, "GR", "geoRegion")))
         assertThat(fromSubGeoRegion, equalTo(PartialNetworkContainer(NetworkLevel.SubGeographicalRegion, "SGR", "subGeoRegion")))
         assertThat(fromSubstation, equalTo(PartialNetworkContainer(NetworkLevel.Substation, "SS", "substation")))
+        assertThat(fromSubstationTotal, equalTo(PartialNetworkContainer(NetworkLevel.SubstationTotal, "SS2", "substation2")))
         assertThat(fromFeeder, equalTo(PartialNetworkContainer(NetworkLevel.Feeder, "FDR", "feeder")))
+        assertThat(fromFeederTotal, equalTo(PartialNetworkContainer(NetworkLevel.FeederTotal, "FDR2", "feeder2")))
         assertThat(fromLvFeeder, equalTo(PartialNetworkContainer(NetworkLevel.LvFeeder, "LVF", "lvFeeder")))
     }
 


### PR DESCRIPTION
# Description

We want to be able to express metrics about both equipment containers and the areas of network they energize (e.g. equipment inside a substation vs all equipment powered by that substation). Therefore, we will make two additional network levels to express this.


# Associated tasks

Tasks blocking this one:
- None

Tasks this is blocking:
- https://github.com/zepben/network-verifier-lib/pull/41

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] ~I have updated the changelog.~
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes.
