### PR TITLE
Bump evolve-conn-jvm with EntraID rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.zepben.evolve</groupId>
             <artifactId>evolve-conn</artifactId>
-            <version>0.8.0</version>
+            <version>0.9.0-SNAPSHOT2</version>
         </dependency>
 
         <!-- Kotlin -->


### PR DESCRIPTION
# Description

Bump evolve-conn to use EntraID instead of Azure.
